### PR TITLE
add ability to provide codecov secret token from caller workflows

### DIFF
--- a/.github/workflows/test-pkg-and-coverage.yml
+++ b/.github/workflows/test-pkg-and-coverage.yml
@@ -20,7 +20,7 @@ on:
         type: string
     secrets:
       CODECOV_TOKEN:
-        type: string
+        description: 'Token for codecov.io'
         required: false
 
 name: test-pkg-and-coverage

--- a/.github/workflows/test-pkg-and-coverage.yml
+++ b/.github/workflows/test-pkg-and-coverage.yml
@@ -18,6 +18,10 @@ on:
         default: '0.9.2'
       extra-packages:
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        type: string
+        required: false
 
 name: test-pkg-and-coverage
 
@@ -48,6 +52,8 @@ jobs:
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()


### PR DESCRIPTION
Caller workflows can now pass secret codecov token to reusable code coverage workflow:

```
name: test-pkg-and-coverage

on:
  push:
    branches: [main, master, develop]
  pull_request:
    branches: [main, master, develop]
  workflow_dispatch:

jobs:
  test-pkg-and-coverage:
    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-pkg-and-coverage.yml@main
    with:
      install-pksim: true
      install-rClr: true
      extra-packages: |
        ospsuite.utils=github::Open-Systems-Pharmacology/OSPSuite.RUtils
        tlf=github::Open-Systems-Pharmacology/TLF-Library
        ospsuite=github::Open-Systems-Pharmacology/OSPSuite-R
        ospsuite.parameteridentification=github::Open-Systems-Pharmacology/OSPSuite.ParameterIdentification
    secrets:
      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN}}
```