### PR TITLE
Bump dev version on functional changes only

### DIFF
--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -31,11 +31,16 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
+            README.md
             NAMESPACE
-            R/**
+            DESCRIPTION
+            NEWS.md
+            .Rbuildignore
+            **.R
+            tests/**
+            vignettes/**
             inst/**
             man/**
-            vignettes/**
 
       - name: Changes detected
         id: set_output


### PR DESCRIPTION
With this PR, the changes are checked before proceeding to automatic version bumps.
Dev version is bumped only if at least one change occured in:
```
- NAMESPACE
- R/**
- inst/**
- man/**
- vignettes/**
```
This way, only **fonctionnal** changes will generate a new version.
For example, if only a test, a github action or an article for the website are changed, the dev version will stay the same as these do not have any impact for the users.

Detected changes that will lead to version bump are listed in the action output:
![image](https://github.com/user-attachments/assets/df8bc7ab-0263-4277-a723-9fbf15184fee)
