### PR TITLE
Add an nunit console runner action

### DIFF
--- a/.github/actions/nunit-console/action.yml
+++ b/.github/actions/nunit-console/action.yml
@@ -1,0 +1,20 @@
+name: 'Nunit console runner'
+description: 'Install and run a test batch with Nunit'
+author: 'Robert McIntosh'
+
+inputs:
+  assemblies:
+    description: 'The assembly glob to run tests against'
+    required: true
+
+
+runs:
+  using: "composite"
+  steps:
+    - id: install-nunit
+      run: nuget install NUnit.ConsoleRunner -Version 3.19.2 -DirectDownload -OutputDirectory .
+      shell: powershell
+
+    - id: run-tests
+      run: ./NUnit.ConsoleRunner.3.19.2/tools/nunit3-console.exe ${{ inputs.assemblies }}
+      shell: powershell


### PR DESCRIPTION
I will probably need this action again after implementing it for SimModel.Solver.CVODES to run tests on a native dll. That's not handled by dotnet test and Nunit is not preinstalled with GitHub runners