### PR TITLE
101 pak to remotes

### DIFF
--- a/.github/actions/setup-qualification-environment/README.md
+++ b/.github/actions/setup-qualification-environment/README.md
@@ -4,9 +4,15 @@ Install OSPSuite tools and Qualification Framework based on csv file input.
 
 Note that this action also installs `Pandoc` and `chromehtml2pdf` allowing conversion of the reports into pdf.
 
+> [!CAUTION]
+> The OSPSuite R packages are installed using `remotes::install_github()` which require a `GITHUB_PAT` to be defined in the environment variables
+
 ## Usage
 
 ```yml
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
 - name: Setup Qualification Environment
   uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-qualification-environment@main
   with:

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -38,13 +38,13 @@ runs:
       name: Install cran packages
       run: |
         # Packages required to remotely install OSPSuite packages
-        install.packages("remotes")
+        install.packages(c("remotes", "pak"))
         print("CRAN Packages suggested and required by ospsuite-r")
-        install.packages(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
+        pak::pkg_install(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
         print("CRAN Packages suggested and required by tlf")
-        install.packages(c('stringr','gridtext','ggtext','showtext','rsvg','svglite','cowplot'))
+        pak::pkg_install(c('stringr','gridtext','ggtext','showtext','rsvg','svglite','cowplot'))
         print("CRAN Packages suggested and required by reporting engine")
-        install.packages(c('jsonlite','rmarkdown','knitr','parallel','readxl','Rmpi'))
+        pak::pkg_install(c('jsonlite','rmarkdown','knitr','parallel','readxl','Rmpi'))
         # Following packages should not be needed c('testthat','covr','pkgdown')
       shell: Rscript {0}
     
@@ -56,12 +56,12 @@ runs:
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
             isTagVersion <- grepl(pattern = "[[:digit:]]\\.[[:digit:]]", x = packageInfo$version)
-            # Check path
-            print(paste0("Open-Systems-Pharmacology/", packageInfo$repo))
-            print(paste0(ifelse(isTagVersion, "v", ""), packageInfo$version))
-            remotes::install_github(
-              repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo),
-              ref = paste0(ifelse(isTagVersion, "v", ""), packageInfo$version)
+            pak::pkg_install(paste0(
+              "Open-Systems-Pharmacology/", 
+              packageInfo$repo, 
+              "@", ifelse(isTagVersion, "v", ""), packageInfo$version
+              ),
+              upgrade = FALSE
             )
             return("Package installed")
           }

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -57,13 +57,11 @@ runs:
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
             isTagVersion <- grepl(pattern = "[[:digit:]]\\.[[:digit:]]", x = packageInfo$version)
-            pak::pkg_install(paste0(
-              "Open-Systems-Pharmacology/", 
-              packageInfo$repo, 
-              "@", ifelse(isTagVersion, "v", ""), packageInfo$version
-              ),
-              upgrade = FALSE
-            )
+            remotes::instal_github(
+              repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo), 
+              ref = paste0(ifelse(isTagVersion, "v", ""), packageInfo$version),
+              upgrade = "never"
+              )
             return("Package installed")
           }
           # Case when install uses url

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -56,6 +56,9 @@ runs:
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
             isTagVersion <- grepl(pattern = "[[:digit:]]\\.[[:digit:]]", x = packageInfo$version)
+            # Check path
+            print(paste0("Open-Systems-Pharmacology/", packageInfo$repo))
+            print(paste0(ifelse(isTagVersion, "v", ""), packageInfo$version))
             remotes::install_github(
               repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo),
               ref = paste0(ifelse(isTagVersion, "v", ""), packageInfo$version)

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -55,9 +55,10 @@ runs:
         toolInstall <- function(packageInfo){
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
+            isTagVersion <- grepl(pattern = "[[:digit:]]\\.[[:digit:]]", x = packageInfo$version)
             remotes::install_github(
               repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo),
-              ref = packageInfo$version
+              ref = paste0(ifelse(isTagVersion, "v", ""), packageInfo$version)
             )
             return("Package installed")
           }

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -6,6 +6,12 @@ inputs:
   tools-path: 
     description: 'Path a csv file defining the tools and versions to install'
     required: true
+  github-pat: 
+    description: 'Github personal access token'
+    required: true
+
+env:
+  GITHUB_PAT: ${{ inputs.github-pat }}
 
 runs:
   using: "composite"
@@ -38,7 +44,7 @@ runs:
       name: Install cran packages
       run: |
         # Packages required to remotely install OSPSuite packages
-        install.packages(c("remotes", "pak", "credentials"))
+        install.packages(c("remotes", "pak"))
         print("CRAN Packages suggested and required by ospsuite-r")
         pak::pkg_install(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
         print("CRAN Packages suggested and required by tlf")
@@ -51,7 +57,6 @@ runs:
     - id: install-ospsuite-tools
       name: Install OSPSuite tools
       run: |
-        credentials::set_github_pat(force_new = TRUE, validate = TRUE)
         # Function to install an R package in tools.csv
         toolInstall <- function(packageInfo){
           # Case when install uses tag or branch

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -55,7 +55,7 @@ runs:
         toolInstall <- function(packageInfo){
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
-            remotes::remotes::install_github(
+            remotes::install_github(
               repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo),
               ref = packageInfo$version
             )

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -56,7 +56,7 @@ runs:
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
             isTagVersion <- grepl(pattern = "[[:digit:]]\\.[[:digit:]]", x = packageInfo$version)
-            remotes::instal_github(
+            remotes::install_github(
               repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo), 
               ref = paste0(ifelse(isTagVersion, "v", ""), packageInfo$version),
               upgrade = "never"

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -38,13 +38,13 @@ runs:
       name: Install cran packages
       run: |
         # Packages required to remotely install OSPSuite packages
-        install.packages(c("remotes", "pak"), repos = 'http://cran.us.r-project.org')
+        install.packages("remotes")
         print("CRAN Packages suggested and required by ospsuite-r")
-        pak::pak(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
+        install.packages(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
         print("CRAN Packages suggested and required by tlf")
-        pak::pak(c('stringr','gridtext','ggtext','showtext','rsvg','svglite','cowplot'))
+        install.packages(c('stringr','gridtext','ggtext','showtext','rsvg','svglite','cowplot'))
         print("CRAN Packages suggested and required by reporting engine")
-        pak::pak(c('jsonlite','rmarkdown','knitr','parallel','readxl','Rmpi'))
+        install.packages(c('jsonlite','rmarkdown','knitr','parallel','readxl','Rmpi'))
         # Following packages should not be needed c('testthat','covr','pkgdown')
       shell: Rscript {0}
     
@@ -55,11 +55,10 @@ runs:
         toolInstall <- function(packageInfo){
           # Case when install uses tag or branch
           if(is.na(packageInfo$url)){
-            isTagVersion <- grepl(pattern = "^\\d+\\.\\d+", packageInfo$version)
-            pak::pak(paste0(
-              "Open-Systems-Pharmacology/", packageInfo$repo,
-              "@", ifelse(isTagVersion, "v", ""), packageInfo$version
-            ))
+            remotes::remotes::install_github(
+              repo = paste0("Open-Systems-Pharmacology/", packageInfo$repo),
+              ref = packageInfo$version
+            )
             return("Package installed")
           }
           # Case when install uses url

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -6,12 +6,6 @@ inputs:
   tools-path: 
     description: 'Path a csv file defining the tools and versions to install'
     required: true
-  github-pat: 
-    description: 'Github personal access token'
-    required: true
-
-env:
-  GITHUB_PAT: ${{ inputs.github-pat }}
 
 runs:
   using: "composite"

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -38,7 +38,7 @@ runs:
       name: Install cran packages
       run: |
         # Packages required to remotely install OSPSuite packages
-        install.packages(c("remotes", "pak"))
+        install.packages(c("remotes", "pak", "credentials"))
         print("CRAN Packages suggested and required by ospsuite-r")
         pak::pkg_install(c('R6','rlang','dplyr','purrr','readr','tidyr','spelling','data.table','tidyselect','openxlsx','xml2'))
         print("CRAN Packages suggested and required by tlf")
@@ -51,6 +51,7 @@ runs:
     - id: install-ospsuite-tools
       name: Install OSPSuite tools
       run: |
+        credentials::set_github_pat(force_new = TRUE, validate = TRUE)
         # Function to install an R package in tools.csv
         toolInstall <- function(packageInfo){
           # Case when install uses tag or branch


### PR DESCRIPTION
Fixes #101 

OSPSuite R packages were installed with `pak` that always update the dependencies, preventing the use of the tools versions as specified by users.

> [!CAUTION]
> remotes::install_github() requires a GITHUB_PAT to be defined in the environment variables

@Yuri05 
A GITHUB_TOKEN secret will be needed for the workflows