### PR TITLE
Fixes #112 Adjust qualification actions for the new artifacts structure

### DIFF
--- a/.github/actions/report-evaluation/action.yaml
+++ b/.github/actions/report-evaluation/action.yaml
@@ -68,8 +68,8 @@ runs:
     - id: run-evaluation
       name: Run evaluation
       run: |
-        qualificationRunnerFolder <- normalizePath("QualificationRunner/QualificationRunner", winslash = "/")
-        pkSimPortableFolder <- normalizePath("PK-Sim/PK-Sim", winslash = "/")
+        qualificationRunnerFolder <- normalizePath("QualificationRunner", winslash = "/")
+        pkSimPortableFolder <- normalizePath("PK-Sim", winslash = "/")
         workingDirectory <- normalizePath("${{ inputs.run-directory }}/${{ inputs.snapshot }}", winslash = "/")
         # Load library and clear simulation cache in case
         library(ospsuite.reportingengine)
@@ -160,7 +160,7 @@ runs:
       run: |
         if(as.logical("${{ inputs.save-model-file }}")){
           workingDirectory <- normalizePath("${{ inputs.run-directory }}/${{ inputs.snapshot }}", winslash = "/")
-          pkSimPath <- normalizePath("PK-Sim/PK-Sim/PKSim.CLI.exe", winslash = "/")
+          pkSimPath <- normalizePath("PK-Sim/PKSim.CLI.exe", winslash = "/")
           cmdLine <- paste(
             pkSimPath,
             "snap",

--- a/.github/actions/setup-qualification-environment/action.yml
+++ b/.github/actions/setup-qualification-environment/action.yml
@@ -140,10 +140,7 @@ runs:
         }
         unzip("pk-sim-portable-setup.zip", exdir = "PK-Sim")
         unlink("pk-sim-portable-setup.zip")
-        file.rename(
-          from = list.files("PK-Sim", full.names = TRUE),
-          to = file.path("PK-Sim", "PK-Sim")
-          )
+
         # Qualification Runner
         if(is.na(toolsData$`Qualification Runner`$url)){
         qualiRunnerURL <- paste0(
@@ -157,8 +154,5 @@ runs:
         }
         unzip("qualificationrunner.zip", exdir = "QualificationRunner")
         unlink("qualificationrunner.zip")
-        file.rename(
-          from = list.files("QualificationRunner", full.names = TRUE),
-          to = file.path("QualificationRunner", "QualificationRunner")
-          )
+
       shell: Rscript {0}


### PR DESCRIPTION
Previously, the artifact archive contained a folder `PK-Sim x.y.z` or `QualiRunner x.y.z` on the top level. 
Is not the case anymore