### PR TITLE
Remove permissions setting from pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,8 +5,6 @@ on:
   
 name: pkgdown
 
-permissions: read-all
-
 jobs:
   pkgdown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed unnecessary permissions setting from pkgdown workflow.

Fixes #147