### PR TITLE
Fix pkgdown covr workflows

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,7 +29,8 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
-        use-public-rspm: true
+        with:
+          use-public-rspm: true
 
       - name: Setup R environment
         id: setup-r-env

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -28,7 +28,8 @@ jobs:
           ref: ${{ github.ref }}
 
       - uses: r-lib/actions/setup-r@v2
-        use-public-rspm: true
+        with:
+          use-public-rspm: true
 
       - name: Setup R environment
         id: setup-r-env


### PR DESCRIPTION
adds `use-public-rspm: true` to use the public version of Posit package manager that serves binaries for Linux and Windows.