### PR TITLE
Fix Rscript command to use --vanilla flag

### DIFF
--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Get package version from DESCRIPTION file and set as environment variable
         shell: bash
         run: |
-            echo "PKG_VERSION=$(Rscript -e 'cat(as.character(desc::desc_get_version()))')" >> $GITHUB_ENV
+            echo "PKG_VERSION=$(Rscript -e --vanilla 'cat(as.character(desc::desc_get_version()))')" >> $GITHUB_ENV
 
       - uses: EndBug/add-and-commit@v9
         if: success()

--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Get package version from DESCRIPTION file and set as environment variable
         shell: bash
         run: |
-            echo "PKG_VERSION=$(Rscript -e --vanilla 'cat(as.character(desc::desc_get_version()))')" >> $GITHUB_ENV
+            echo "PKG_VERSION=$(Rscript --vanilla -e 'cat(as.character(desc::desc_get_version()))')" >> $GITHUB_ENV
 
       - uses: EndBug/add-and-commit@v9
         if: success()


### PR DESCRIPTION
Fixes this issue:
```r
Run echo "PKG_VERSION=$(Rscript -e 'cat(as.character(desc::desc_get_version()))')" >> $GITHUB_ENV
Error: Unable to process file command 'env' successfully.
Error: Invalid format '- Use `renv::status()` for more details.'
```