### PR TITLE
Update setup-re-env action on MacOS (missing headers)

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -22,7 +22,10 @@ runs:
 
     - name: Install gettext (for libintl.h)
       if: runner.os == 'macOS'
-      run: brew install gettext
+      run: |
+        brew install gettext
+        echo "CPPFLAGS=-I$(brew --prefix gettext)/include ${CPPFLAGS:-}" >> $GITHUB_ENV
+        echo "LDFLAGS=-L$(brew --prefix gettext)/lib ${LDFLAGS:-}" >> $GITHUB_ENV
       shell: bash
     
     - name: Setup renv


### PR DESCRIPTION
Seems that simple instal of gettext is not enough (still the same error on macOS: https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/runs/22392461965/job/64817681046?pr=1738)

So trying the suggestion https://github.com/Open-Systems-Pharmacology/Workflows/pull/176/changes#r2847236648 by CodeWabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build environment configuration to better manage system dependencies and enhance overall build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->