### PR TITLE
Refactor workflows to use setup-r-env composite action and remove R d…

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -1,7 +1,23 @@
-name: 'Setup R environment (renv or dependencies)'
-description: 'Detects renv.lock and sets up either renv or R dependencies accordingly'
+name: 'Setup R environment'
+description: 'Sets up a complete R environment: R, pandoc, dotnet workaround, and renv or dependencies'
 
 inputs:
+  r-version:
+    description: 'R version to install (e.g. "release", "devel", "4.3.1")'
+    required: false
+    default: 'release'
+  use-public-rspm:
+    description: 'Use public RStudio Package Manager'
+    required: false
+    default: 'true'
+  setup-pandoc:
+    description: 'Whether to install pandoc'
+    required: false
+    default: 'false'
+  setup-quarto:
+    description: 'Whether to install Quarto'
+    required: false
+    default: 'false'
   ignore-renv:
     description: 'Skip renv setup if set to true'
     required: false
@@ -11,24 +27,38 @@ outputs:
   renv_detected:
     description: 'Whether renv.lock was detected'
     value: ${{ steps.check-renv.outputs.renv_detected }}
+  installed-r-version:
+    description: 'The installed R version'
+    value: ${{ steps.setup-r.outputs.installed-r-version }}
 
 runs:
   using: composite
   steps:
+    - name: Set DOTNET_ROOT for macOS
+      if: runner.os == 'macOS'
+      run: echo "DOTNET_ROOT=$HOME/.dotnet" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Setup pandoc
+      if: inputs.setup-pandoc == 'true'
+      uses: r-lib/actions/setup-pandoc@v2
+
+    - name: Setup Quarto
+      if: inputs.setup-quarto == 'true'
+      uses: quarto-dev/quarto-actions/setup@v2
+
+    - name: Setup R
+      id: setup-r
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{ inputs.r-version }}
+        use-public-rspm: ${{ inputs.use-public-rspm }}
+
     - name: Check for renv.lock
       id: check-renv
       run: echo "renv_detected=$([ -f renv.lock ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Install gettext (for libintl.h)
-      if: runner.os == 'macOS'
-      run: |
-        brew install gettext
-        mkdir -p ~/.R
-        echo "CPPFLAGS += -I$(brew --prefix gettext)/include" >> ~/.R/Makevars
-        echo "LDFLAGS += -L$(brew --prefix gettext)/lib" >> ~/.R/Makevars
-      shell: bash
-    
     - name: Setup renv
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
       uses: r-lib/actions/setup-renv@v2

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Setup .NET
       if: runner.os == 'macOS'
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Whether to install Quarto'
     required: false
     default: 'false'
+  dotnet-version:
+    description: '.NET version to install on macOS (e.g. "8.0.x", "9.0.x")'
+    required: false
+    default: '8.0.x'
   ignore-renv:
     description: 'Skip renv setup if set to true'
     required: false
@@ -34,10 +38,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set DOTNET_ROOT for macOS
+    - name: Setup .NET
       if: runner.os == 'macOS'
-      run: echo "DOTNET_ROOT=$HOME/.dotnet" >> $GITHUB_ENV
-      shell: bash
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
 
     - name: Setup pandoc
       if: inputs.setup-pandoc == 'true'

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -71,5 +71,3 @@ runs:
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'
       uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        cache: false

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -35,22 +35,12 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set DOTNET_ROOT for macOS
-        if: runner.os == 'macOS'
-        run:  echo "DOTNET_ROOT=$HOME/.dotnet" >> $GITHUB_ENV
-    
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        id: setup-r
-        with:
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: true
-
       - name: Setup R environment
         id: setup-r-env
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
+          r-version: ${{ matrix.config.r }}
+          setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
 
       - name: Check R package
@@ -84,7 +74,7 @@ jobs:
         run: |
           echo "PKG_NAME=$(grep '^Package:' DESCRIPTION | sed 's/^Package:[[:space:]]*//')" >> $GITHUB_ENV
           echo "PKG_VERSION=$(grep '^Version:' DESCRIPTION | sed 's/^Version:[[:space:]]*//')" >> $GITHUB_ENV
-          echo "R_VERSION=${{ steps.setup-r.outputs.installed-r-version }}" >> $GITHUB_ENV
+          echo "R_VERSION=${{ steps.setup-r-env.outputs.installed-r-version }}" >> $GITHUB_ENV
         shell: bash
 
       - name: Upload built package

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -25,6 +25,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -1,0 +1,76 @@
+on:
+  workflow_call:
+
+name: R-CMD-check (released deps)
+
+permissions: read-all
+
+jobs:
+  R-CMD-check-released-deps:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}) [Released Deps]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: macos-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pin Remotes to released versions
+        shell: bash
+        run: |
+          if ! grep -q '^Remotes:' DESCRIPTION; then
+            echo "No Remotes field found in DESCRIPTION, skipping."
+            exit 0
+          fi
+
+          # Use awk to process the multiline Remotes field in-place:
+          # - Strip any @ref suffix from each remote entry
+          # - Append @*release to each remote entry
+          awk '
+            /^Remotes:/ { in_remotes=1; print; next }
+            in_remotes && /^[^ \t]/ { in_remotes=0 }
+            in_remotes {
+              # Remove existing @ref suffix, then append @*release
+              gsub(/@[^,]*/, "")
+              gsub(/([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)/, "&@*release")
+              print; next
+            }
+            { print }
+          ' DESCRIPTION > DESCRIPTION.tmp && mv DESCRIPTION.tmp DESCRIPTION
+
+          echo "Remotes pinned to released versions:"
+          awk '/^Remotes:/{in_r=1; print; next} in_r && /^[^ \t]/{exit} in_r{print}' DESCRIPTION
+
+      - name: Setup R environment
+        id: setup-r-env
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        with:
+          r-version: ${{ matrix.config.r }}
+          setup-pandoc: 'true'
+          ignore-renv: 'true'
+
+      - name: Check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          args: 'c("--no-manual", "--no-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          error-on: 'c("error")'
+
+      - name: Diagnostic message on failure
+        if: failure()
+        run: |
+          echo "::warning::This workflow tests the package against the latest *released* versions of OSP dependencies."
+          echo "::warning::If the main R-CMD-Check workflow passes but this one fails, it means the package works with development dependencies but not with the currently released ones."
+          echo "::warning::A new release of one or more OSP dependencies is likely needed before this package can be released."

--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -2,6 +2,7 @@
 # This reusable workflow will, if triggered by a merge:
 #  - Bump version if the current version is development (x.y.z.9000+) & if functional changes are detected.
 #  - Specify Remotes to point to @*release versions for the current package released version
+#  - Tag the target branch with version number (only for non-dev versions)
 name: bump-dev-version
 
 on:
@@ -85,51 +86,74 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install packages
-        run: |
-          install.packages("usethis")
-        shell: Rscript {0}
-
       - name: Change DESCRIPTION file
-        shell: Rscript {0}
+        shell: bash
         run: |
-          # Bump version if in development
-          if (usethis:::is_dev_version()) {
-            desc::desc_set_version(version = usethis:::bump_version()[["dev"]])
-          }
+          # Read current version from DESCRIPTION
+          version=$(grep '^Version:' DESCRIPTION | sed 's/^Version:[[:space:]]*//')
+          echo "Current version: $version"
+
+          # Check if version is a dev version (has 4 components, e.g. 1.2.3.9000)
+          if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)$ ]]; then
+            base="${BASH_REMATCH[1]}"
+            dev=$((BASH_REMATCH[2] + 1))
+            new_version="${base}.${dev}"
+            echo "Dev version detected. Bumping: $version -> $new_version"
+            sed -i "s/^Version:.*/Version: $new_version/" DESCRIPTION
+            is_dev=true
+          else
+            echo "Release version detected, no version bump needed."
+            is_dev=false
+          fi
 
           # Adjust Remotes field based on version type
-          if (desc::desc_has_fields("Remotes")) {
-            remotes <- desc::desc_get_remotes()
-            # Strip trailing whitespace first for clean comparison
-            remotes <- sub("\\s+$", "", remotes)
+          if grep -q '^Remotes:' DESCRIPTION; then
+            if [ "$is_dev" = true ]; then
+              # Remove @*release from remotes
+              awk '
+                /^Remotes:/ { in_remotes=1; print; next }
+                in_remotes && /^[^ \t]/ { in_remotes=0 }
+                in_remotes { gsub(/@\*release/, ""); print; next }
+                { print }
+              ' DESCRIPTION > DESCRIPTION.tmp && mv DESCRIPTION.tmp DESCRIPTION
+              echo "Remotes: removed @*release"
+            else
+              # Add @*release to remotes that don't already have it
+              awk '
+                /^Remotes:/ { in_remotes=1; print; next }
+                in_remotes && /^[^ \t]/ { in_remotes=0 }
+                in_remotes {
+                  # For each org/repo entry without @*release, append it
+                  if ($0 !~ /@\*release/) {
+                    gsub(/([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)(,?)$/, "\\1@*release\\2")
+                  }
+                  print; next
+                }
+                { print }
+              ' DESCRIPTION > DESCRIPTION.tmp && mv DESCRIPTION.tmp DESCRIPTION
+              echo "Remotes: added @*release"
+            fi
 
-            if (usethis:::is_dev_version()) {
-              # Remove @*release from any remote that has it
-              remotes <- gsub("@\\*release$", "", remotes)
-              action <- "removed @*release"
-            } else {
-              # Add @*release to any remote that doesn't already have it
-              remotes <- ifelse(grepl("@\\*release$", remotes),
-                                remotes,
-                                paste0(remotes, "@*release"))
-              action <- "added @*release"
-            }
+            echo "Updated Remotes:"
+            awk '/^Remotes:/{in_r=1; print; next} in_r && /^[^ \t]/{exit} in_r{print}' DESCRIPTION
+          else
+            echo "No Remotes field found in DESCRIPTION"
+          fi
 
-            desc::desc_set_remotes(remotes)
-            cat("\nModified DESCRIPTION Remotes field (", action, "):\n", sep = "")
-            cat(paste(remotes, collapse = "\n"), "\n")
-          } else {
-            cat("No Remotes field found in DESCRIPTION\n")
-          }
+          # Export version info for subsequent steps
+          final_version=$(grep '^Version:' DESCRIPTION | sed 's/^Version:[[:space:]]*//')
+          echo "PKG_VERSION=$final_version" >> $GITHUB_ENV
+          echo "IS_DEV_VERSION=$is_dev" >> $GITHUB_ENV
+
       - uses: EndBug/add-and-commit@v9
         if: success()
         with:
           message: '🤖 Bump version. [skip actions]'
           default_author: github_actions
           add: 'DESCRIPTION'
+
+      - uses: thejeff77/action-push-tag@v1.0.0
+        if: success() && env.IS_DEV_VERSION == 'false'
+        with:
+          tag: v${{ env.PKG_VERSION }}
+          force: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
         with:
           setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,16 +26,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
       - name: Setup R environment
         id: setup-r-env
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
+          setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
 
       - name: Install extra packages

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
         with:
           ignore-renv: ${{ inputs.ignore-renv }}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           ignore-renv: ${{ inputs.ignore-renv }}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,10 +27,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
       - name: Setup R environment
         id: setup-r-env
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up R
-
-      - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -68,7 +68,7 @@ jobs:
           path: .
 
       - name: Setup R environment
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           setup-pandoc: 'true'
 

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -10,8 +10,7 @@ on:
       private-key:
         required: true
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   update-renv-lock:
@@ -79,6 +78,8 @@ jobs:
     needs: test-on-platforms
     runs-on: ubuntu-latest
     if: needs.test-on-platforms.result == 'success'
+    permissions:
+      contents: write
 
     steps:
       - name: Generate token from GitHub App

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -22,9 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup .NET
-        if: runner.os == 'macOS'
-        uses: actions/setup-dotnet@v5
+      - name: Set up R
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -1,0 +1,111 @@
+name: Update renv snapshot and check package
+
+on:
+  workflow_call:
+    inputs:
+      app-id:
+        type: string
+        required: true
+    secrets:
+      private-key:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  update-renv-lock:
+    runs-on: ubuntu-latest
+    name: Update renv.lock
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        if: runner.os == 'macOS'
+        uses: actions/setup-dotnet@v5
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install renv
+        run: Rscript -e "install.packages('renv')"
+
+
+      - name: Update packages at latest versions and snapshot
+        run: Rscript -e "renv::update(lock = TRUE)"
+
+      - name: Upload updated renv.lock
+        uses: actions/upload-artifact@v7
+        with:
+          name: renv-lock
+          path: renv.lock
+          retention-days: 1
+
+  test-on-platforms:
+    needs: update-renv-lock
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    name: Test on ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download updated renv.lock
+        uses: actions/download-artifact@v8
+        with:
+          name: renv-lock
+          path: .
+
+      - name: Setup R environment
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@refactor/reusable-workflows-and-composite-actions
+        with:
+          setup-pandoc: 'true'
+
+      - name: Check R package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          error-on: 'c("error")'
+
+  commit-renv-lock:
+    needs: test-on-platforms
+    runs-on: ubuntu-latest
+    if: needs.test-on-platforms.result == 'success'
+
+    steps:
+      - name: Generate token from GitHub App
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download updated renv.lock
+        uses: actions/download-artifact@v8
+        with:
+          name: renv-lock
+          path: .
+
+      - name: Commit renv.lock if changed
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: '🤖 Update renv.lock [skip actions]'
+          default_author: github_actions
+          add: 'renv.lock'


### PR DESCRIPTION
…ependency

- Consolidate R, pandoc, quarto, and .NET setup into the setup-r-env composite action
- Remove duplicated setup steps from R-CMD-check-build, pkgdown, and test-coverage workflows
- Rewrite R-CMD-check-released-deps as a reusable workflow (workflow_call), pin Remotes via bash/awk
- Replace R-based version bump and Remotes logic in bump_dev_version_tag_branch with pure bash
- Integrate PR #203: re-enable automatic tagging for non-dev versions
- Add setup-quarto option to setup-r-env composite action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable workflow to update and commit renv lockfiles and validate package checks across OSes.
  * Added a workflow to run package checks using released dependency versions across Windows, Linux, and macOS.

* **Refactor**
  * Consolidated R environment provisioning into a single configurable setup (R version, pandoc/Quarto optional, macOS .NET support) and expose the installed R version.

* **Workflow**
  * Updated multiple workflows to use the consolidated R setup, streamlined version/remotes handling, and added a macOS release matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->