### PR TITLE
Skip downstream jobs when renv.lock is unchanged

### DIFF
--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -14,6 +14,8 @@ jobs:
   update-renv-lock:
     runs-on: ubuntu-latest
     name: Update renv.lock
+    outputs:
+      lockfile-changed: ${{ steps.check-changes.outputs.changed }}
 
     steps:
       - name: Checkout repository
@@ -27,11 +29,22 @@ jobs:
       - name: Install renv
         run: Rscript -e "install.packages('renv')"
 
-
       - name: Update packages at latest versions and snapshot
         run: Rscript -e "renv::update(lock = TRUE)"
 
+      - name: Check if renv.lock changed
+        id: check-changes
+        run: |
+          if git diff --quiet renv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "renv.lock is unchanged, skipping downstream jobs."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "renv.lock has been updated."
+          fi
+
       - name: Upload updated renv.lock
+        if: steps.check-changes.outputs.changed == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: renv-lock
@@ -40,6 +53,7 @@ jobs:
 
   test-on-platforms:
     needs: update-renv-lock
+    if: needs.update-renv-lock.outputs.lockfile-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -73,9 +87,9 @@ jobs:
           error-on: 'c("error")'
 
   commit-renv-lock:
-    needs: test-on-platforms
+    needs: [update-renv-lock, test-on-platforms]
     runs-on: ubuntu-latest
-    if: needs.test-on-platforms.result == 'success'
+    if: needs.update-renv-lock.outputs.lockfile-changed == 'true' && needs.test-on-platforms.result == 'success'
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- After `renv::update()`, detect whether `renv.lock` actually changed using `git diff --quiet`
- Skip cross-platform testing and commit jobs when no packages were updated, avoiding unnecessary runner usage
- Artifact upload is also skipped when there are no changes

## Context
When `renv::update()` finds all packages up-to-date, the lockfile is unchanged. Previously the workflow still ran 3 platform tests and a commit job — all pointless in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to conditionally run tests and commits only when dependency files are modified, reducing unnecessary workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->