### PR TITLE
Optimize CI workflows: skip binary on PRs, parameterize matrix, filter pkgdown

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Whether to install pandoc'
     required: false
     default: 'false'
+  setup-tinytex:
+    description: 'Whether to install TinyTeX (provides pdflatex for PDF manual builds)'
+    required: false
+    default: 'false'
   setup-quarto:
     description: 'Whether to install Quarto'
     required: false
@@ -51,6 +55,12 @@ runs:
     - name: Setup Quarto
       if: inputs.setup-quarto == 'true'
       uses: quarto-dev/quarto-actions/setup@v2
+
+    - name: Setup TinyTeX
+      if: inputs.setup-tinytex == 'true'
+      uses: r-lib/actions/setup-tinytex@v2
+      env:
+        TINYTEX_INSTALLER: TinyTeX
 
     - name: Setup R
       id: setup-r

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      os-matrix:
+        description: 'JSON array of {os, r} objects for the build matrix. Defaults to all three platforms with R release.'
+        required: false
+        type: string
+        default: '[{"os": "windows-latest", "r": "release"}, {"os": "ubuntu-latest", "r": "release"}, {"os": "macos-latest", "r": "release"}]'
 
 name: R-CMD-check
 
@@ -22,10 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: macos-latest,   r: 'release'}
+        config: ${{ fromJSON(inputs.os-matrix) }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: '[{"os": "windows-latest", "r": "release"}, {"os": "ubuntu-latest", "r": "release"}, {"os": "macos-latest", "r": "release"}]'
+      build-binary:
+        description: 'Whether to build and upload the binary package. Set to false on PRs to save ~4 min per OS.'
+        required: false
+        type: boolean
+        default: true
 
 name: R-CMD-check
 
@@ -50,30 +55,30 @@ jobs:
         uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          args: 'c("--no-manual", "--no-vignettes")'
-          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          args: 'c("--no-vignettes")'
           error-on: 'c("error")'
 
       - name: Install extra packages
+        if: inputs.build-binary
         run: |
-          packages <- c("rcmdcheck", "devtools", "pkgload", "desc")
+          packages <- c("devtools")
           missing <- packages[!packages %in% rownames(installed.packages())]
           if (length(missing) > 0) {
             install.packages(missing)
           }
         shell: Rscript {0}
 
-      - name: Build package
-        if: success()
+      - name: Build binary from check tarball
+        if: inputs.build-binary
         run: |
+          tarball <- list.files("check", pattern = "\\.tar\\.gz$", full.names = TRUE)
           output_dir <- file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "built_package")
           dir.create(output_dir)
-          # first run build() to get a bundle package (that includes rendered vignettes), then create binary.
-          devtools::build(devtools::build(), binary = TRUE, path = output_dir, args=c("--preclean", "--install-tests"))
+          devtools::build(tarball, binary = TRUE, path = output_dir, args = c("--preclean", "--install-tests"))
         shell: Rscript {0}
 
       - name: Get package name, version and R versions and store in environment
-        if: success()
+        if: inputs.build-binary
         run: |
           echo "PKG_NAME=$(grep '^Package:' DESCRIPTION | sed 's/^Package:[[:space:]]*//')" >> $GITHUB_ENV
           echo "PKG_VERSION=$(grep '^Version:' DESCRIPTION | sed 's/^Version:[[:space:]]*//')" >> $GITHUB_ENV
@@ -81,7 +86,7 @@ jobs:
         shell: bash
 
       - name: Upload built package
-        if: success()
+        if: inputs.build-binary
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PKG_NAME }}-v${{ env.PKG_VERSION }}-${{runner.os}}-r_${{ env.R_VERSION }}

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,10 +45,11 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@ci/optimize-r-cmd-check
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'
+          setup-tinytex: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
 
       - name: Check R package

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@ci/optimize-r-cmd-check
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -1,5 +1,11 @@
 on:
   workflow_call:
+    inputs:
+      os-matrix:
+        description: 'JSON array of {os, r} objects for the build matrix. Defaults to all three platforms with R release.'
+        required: false
+        type: string
+        default: '[{"os": "windows-latest", "r": "release"}, {"os": "ubuntu-latest", "r": "release"}, {"os": "macos-latest", "r": "release"}]'
 
 name: R-CMD-check (released deps)
 
@@ -14,10 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,  r: 'release'}
-          - {os: macos-latest,   r: 'release'}
+        config: ${{ fromJSON(inputs.os-matrix) }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,11 +8,41 @@ on:
         required: false
         type: boolean
         default: false
+      doc-path-filters:
+        description: 'YAML string for dorny/paths-filter. On PRs, pkgdown is skipped when none of these paths changed. Ignored on push events.'
+        required: false
+        type: string
+        default: |
+          docs:
+            - 'man/**'
+            - 'vignettes/**'
+            - '_pkgdown.yml'
+            - '_pkgdown.yaml'
+            - 'pkgdown/**'
+            - 'README.md'
+            - 'DESCRIPTION'
+            - 'NEWS.md'
+            - 'R/**'
 
 name: pkgdown
 
 jobs:
+  check-changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: ${{ inputs.doc-path-filters }}
+
   pkgdown:
+    needs: [check-changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.check-changes.outputs.docs == 'true') }}
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:


### PR DESCRIPTION
## Summary

- **Skip pkgdown on non-doc PRs**: Use `dorny/paths-filter` to skip pkgdown builds when no documentation files changed (~7 min saved per non-doc PR). Filter paths are configurable via `doc-path-filters` input.
- **Parameterize OS matrix**: Replace hardcoded OS matrices in `R-CMD-check-build` and `R-CMD-check-released-deps` with a configurable `os-matrix` input, allowing callers to customize which platforms to check.
- **Add `build-binary` input**: Skip binary package build and upload on PRs (~4 min saved per OS, ~12 min total across the matrix). Defaults to `true` for backwards compatibility.
- **Reuse check tarball for binary build**: Build the binary from the source tarball already produced by `R CMD check` instead of running `devtools::build()` twice.
- **Enable manual and vignettes in build**: Remove `--no-manual` and `--no-build-vignettes` from build args so the tarball (and resulting binary) includes rendered vignettes and manual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now accepts caller-specified platform/R matrices and a toggle to enable or skip binary builds.
  * Package checks can include vignettes/manuals depending on the build settings.
  * Documentation site build runs on PRs only when docs-related files changed.
  * R environment setup gains an optional TinyTeX install to enable PDF/manual generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->