### PR TITLE
Speed up Windows renv setup (~22 min → ~3.5 min)

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -76,11 +76,9 @@ runs:
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os != 'Windows'
       uses: r-lib/actions/setup-renv@v2
 
-    # Windows: cache R packages in a dedicated library to avoid renv's slow
-    # file copy (~20 min). Windows can't hardlink, so renv copies thousands
-    # of small files from global cache to project library on every restore.
-    # Instead, we point R_LIBS_USER to a cacheable absolute path and install
-    # there once. On cache hit, R finds packages directly — no renv needed.
+    # Windows: point R_LIBS_USER to a cacheable absolute path and install
+    # packages there via renv::restore(library=...) on cache miss.
+    # On cache hit, R finds packages directly — no renv restore needed.
     - name: Configure R library for caching (Windows)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
       shell: bash

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -59,8 +59,6 @@ runs:
     - name: Setup TinyTeX
       if: inputs.setup-tinytex == 'true'
       uses: r-lib/actions/setup-tinytex@v2
-      env:
-        TINYTEX_INSTALLER: TinyTeX
 
     - name: Setup R
       id: setup-r

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -76,24 +76,20 @@ runs:
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os != 'Windows'
       uses: r-lib/actions/setup-renv@v2
 
-    - name: Set renv cache path (Windows)
-      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
-      shell: bash
-      run: echo "RENV_PATHS_ROOT=${{ runner.temp }}/renv" >> $GITHUB_ENV
-
+    # Windows: cache the renv project library directly to skip the slow
+    # renv::restore() copy step (Windows can't hardlink, so renv copies
+    # thousands of small files — ~20 min). On cache hit, renv/activate.R
+    # (sourced from .Rprofile) sets up library paths automatically.
     - name: Cache renv library (Windows)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+      id: cache-renv-win
       uses: actions/cache@v4
       with:
-        path: |
-          ${{ runner.temp }}/renv
-          renv/library
+        path: renv/library
         key: renv-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('renv.lock') }}
-        restore-keys: |
-          renv-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-
 
-    - name: Restore renv packages (Windows)
-      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+    - name: Restore renv packages (Windows, cache miss)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows' && steps.cache-renv-win.outputs.cache-hit != 'true'
       shell: Rscript {0}
       run: |
         if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -77,6 +77,8 @@ runs:
     - name: Setup renv
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
       uses: r-lib/actions/setup-renv@v2
+      env:
+        RENV_CONFIG_PPM_ENABLED: 'true'
 
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -74,11 +74,32 @@ runs:
       run: echo "renv_detected=$([ -f renv.lock ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Setup renv
-      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
+    - name: Setup renv (Linux/macOS)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os != 'Windows'
       uses: r-lib/actions/setup-renv@v2
-      env:
-        RENV_CONFIG_PPM_ENABLED: 'true'
+
+    - name: Set renv cache path (Windows)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+      shell: bash
+      run: echo "RENV_PATHS_ROOT=${{ runner.temp }}/renv" >> $GITHUB_ENV
+
+    - name: Cache renv library (Windows)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ runner.temp }}/renv
+          renv/library
+        key: renv-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('renv.lock') }}
+        restore-keys: |
+          renv-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-
+
+    - name: Restore renv packages (Windows)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+      shell: Rscript {0}
+      run: |
+        if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+        renv::restore()
 
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -76,24 +76,35 @@ runs:
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os != 'Windows'
       uses: r-lib/actions/setup-renv@v2
 
-    # Windows: cache the renv project library directly to skip the slow
-    # renv::restore() copy step (Windows can't hardlink, so renv copies
-    # thousands of small files — ~20 min). On cache hit, renv/activate.R
-    # (sourced from .Rprofile) sets up library paths automatically.
-    - name: Cache renv library (Windows)
+    # Windows: cache R packages in a dedicated library to avoid renv's slow
+    # file copy (~20 min). Windows can't hardlink, so renv copies thousands
+    # of small files from global cache to project library on every restore.
+    # Instead, we point R_LIBS_USER to a cacheable absolute path and install
+    # there once. On cache hit, R finds packages directly — no renv needed.
+    - name: Configure R library for caching (Windows)
+      if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
+      shell: bash
+      run: |
+        R_LIB_PATH="${{ runner.temp }}/R-lib"
+        mkdir -p "${R_LIB_PATH}"
+        echo "R_LIBS_USER=${R_LIB_PATH}" >> $GITHUB_ENV
+        echo "RENV_CONFIG_AUTOLOADER_ENABLED=FALSE" >> $GITHUB_ENV
+
+    - name: Cache R library (Windows)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
       id: cache-renv-win
       uses: actions/cache@v4
       with:
-        path: renv/library
-        key: renv-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('renv.lock') }}
+        path: ${{ runner.temp }}/R-lib
+        key: r-lib-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('renv.lock') }}
 
-    - name: Restore renv packages (Windows, cache miss)
+    - name: Install packages from renv.lock (Windows, cache miss)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows' && steps.cache-renv-win.outputs.cache-hit != 'true'
       shell: Rscript {0}
       run: |
-        if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-        renv::restore()
+        lib <- Sys.getenv("R_LIBS_USER")
+        if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv", lib = lib)
+        renv::restore(library = lib)
 
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@ci/optimize-r-cmd-check
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@optimize-renv-cache
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Felixmil/Workflows/.github/actions/setup-r-env@ci/optimize-r-cmd-check
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup R environment
         id: setup-r-env
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
+        uses: Felixmil/Workflows/.github/actions/setup-r-env@optimize-renv-cache
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'


### PR DESCRIPTION
## Summary

- **Windows renv cache**: On Windows, `renv::restore()` copies thousands of small files (~22 min) because it can't use hardlinks. This PR redirects `R_LIBS_USER` to a cached absolute path under `RUNNER_TEMP` and installs there via `renv::restore(library=...)`. On cache hit, R finds packages directly — no restore needed. Same pattern as the [qualification reports setup](https://github.com/Open-Systems-Pharmacology/Create-Qualification-Reports/blob/main/.github/actions/setup-qualification-environment/action.yml) ([#205 discussion](https://github.com/Open-Systems-Pharmacology/Workflows/issues/205#issuecomment-4222690971)).
  - [Before](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/runs/24310816907) (main): **21m 39s** | [After](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/actions/runs/24335318050) (cache hit): **3m 28s**


Relates to #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized R environment setup with platform-specific behavior to improve build reliability
  * Implemented caching for Windows builds to speed up dependency restoration
  * Enhanced conditional handling for dependency lock file detection and restore logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->