### PR TITLE
 bump actions versions, restore vignette checks, and skip unnecessary PDF/TinyTeX setup 

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -91,7 +91,7 @@ runs:
     - name: Cache R library (Windows)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os == 'Windows'
       id: cache-renv-win
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/R-lib
         key: r-lib-${{ runner.os }}-${{ steps.setup-r.outputs.installed-r-version }}-${{ hashFiles('renv.lock') }}

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -39,7 +39,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -49,14 +49,15 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'
-          setup-tinytex: 'true'
+          setup-tinytex: 'false'
           ignore-renv: ${{ inputs.ignore-renv }}
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          args: 'c("--no-vignettes")'
+          args: 'c("--no-manual")'
+          build_args: 'c("--no-manual")'
           error-on: 'c("error")'
 
       - name: Install extra packages

--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       run_next_job: ${{ steps.set_output.outputs.run_next_job }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.private-key }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 


### PR DESCRIPTION
Fully skip PDF manual build because:
- it takes time
- pdf manual is not included in binary package anyway (and who use them nowadays?)

\+ Restore vignette checks to avoid confusing situations when RCMDCheck passes but not pkgdown action.

\+ update actions