### PR TITLE
Add required-packages to setup-r-env, remove ad-hoc install steps

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Skip renv setup if set to true'
     required: false
     default: 'false'
+  required-packages:
+    description: 'R packages that must be available after setup, one per line. For non-renv projects, installs via setup-r-dependencies. For renv projects, only verifies (errors with instructions if missing).'
+    required: false
+    default: ''
 
 outputs:
   renv_detected:
@@ -107,3 +111,45 @@ runs:
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'
       uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        extra-packages: ${{ inputs.required-packages }}
+
+    - name: Verify required packages
+      if: inputs.required-packages != ''
+      shell: Rscript {0}
+      env:
+        REQUIRED_PACKAGES: ${{ inputs.required-packages }}
+        RENV_DETECTED: ${{ steps.check-renv.outputs.renv_detected }}
+        IGNORE_RENV: ${{ inputs.ignore-renv }}
+      run: |
+        required <- strsplit(Sys.getenv("REQUIRED_PACKAGES"), "\\s+")[[1]]
+        required <- required[nzchar(required)]
+        if (length(required) == 0L) quit("no")
+
+        missing <- required[!vapply(required, requireNamespace, logical(1), quietly = TRUE)]
+        if (length(missing) == 0L) quit("no")
+
+        renv_active <- identical(Sys.getenv("RENV_DETECTED"), "true") &&
+          !identical(tolower(Sys.getenv("IGNORE_RENV")), "true")
+
+        pkgs_str <- paste(sprintf("'%s'", missing), collapse = ", ")
+        pkgs_install <- paste(sprintf('"%s"', missing), collapse = ", ")
+
+        if (renv_active) {
+          msg <- paste(
+            sprintf("Required packages not installed: %s", pkgs_str),
+            "This project uses renv. To fix, run locally:",
+            sprintf("  1. Add %s to 'Suggests' in DESCRIPTION", pkgs_str),
+            sprintf("  2. renv::install(c(%s))", pkgs_install),
+            "  3. renv::snapshot()",
+            "  4. Commit the updated renv.lock",
+            sep = "\n"
+          )
+        } else {
+          msg <- paste(
+            sprintf("Required packages not installed: %s", pkgs_str),
+            sprintf("Add %s to 'Suggests' in DESCRIPTION", pkgs_str),
+            sep = "\n"
+          )
+        }
+        stop(msg, call. = FALSE)

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -18,7 +18,6 @@ on:
         required: false
         type: boolean
         default: true
-
 name: R-CMD-check
 
 permissions: read-all
@@ -51,6 +50,9 @@ jobs:
           setup-pandoc: 'true'
           setup-tinytex: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
+          required-packages: |
+            rcmdcheck
+            ${{ inputs.build-binary && 'pkgbuild' || '' }}
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2
@@ -59,24 +61,20 @@ jobs:
           args: 'c("--no-vignettes")'
           error-on: 'c("error")'
 
-      - name: Install extra packages
+      - name: Build binary package
         if: inputs.build-binary
-        run: |
-          packages <- c("devtools")
-          missing <- packages[!packages %in% rownames(installed.packages())]
-          if (length(missing) > 0) {
-            install.packages(missing)
-          }
         shell: Rscript {0}
-
-      - name: Build binary from check tarball
-        if: inputs.build-binary
         run: |
-          tarball <- list.files("check", pattern = "\\.tar\\.gz$", full.names = TRUE)
           output_dir <- file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "built_package")
-          dir.create(output_dir)
-          devtools::build(tarball, binary = TRUE, path = output_dir, args = c("--preclean", "--install-tests"))
-        shell: Rscript {0}
+          dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+          tarball <- list.files("check", pattern = "\\.tar\\.gz$", full.names = TRUE)[1]
+          built <- pkgbuild::build(
+            path = tarball,
+            dest_path = output_dir,
+            binary = TRUE,
+            args = c("--preclean", "--install-tests")
+          )
+          cat("Built binary:", built, "\n")
 
       - name: Get package name, version and R versions and store in environment
         if: inputs.build-binary

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -62,16 +62,11 @@ jobs:
         with:
           setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
+          required-packages: pkgdown
 
-      - name: Install extra packages
-        run: |
-          if (!requireNamespace("pkgdown", quietly = TRUE)) {
-            install.packages("pkgdown")
-          }
-          if (!requireNamespace("devtools", quietly = TRUE)) {
-            install.packages("devtools")
-          }
-          devtools::install(".", upgrade = FALSE)
+      - name: Install Local package
+        id: install-local
+        run: pak::local_install(dependencies = FALSE)
         shell: Rscript {0}
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -32,16 +32,7 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           ignore-renv: ${{ inputs.ignore-renv }}
-
-      - name: Install extra packages
-        run: |
-          if (!requireNamespace("covr", quietly = TRUE)) {
-            install.packages("covr")
-          }
-          if (!requireNamespace("xml2", quietly = TRUE)) {
-            install.packages("xml2")
-          }
-        shell: Rscript {0}
+          required-packages: covr
 
       - name: Test coverage
         run: |
@@ -53,7 +44,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
           file: ./cobertura.xml


### PR DESCRIPTION
## Summary

- Add `required-packages` input to `setup-r-env` action that:
  - Installs packages via `setup-r-dependencies` for non-renv projects
  - Verifies packages are available after setup (all projects)
  - Provides renv-aware error messages with fix instructions when packages missing

- Replace ad-hoc `install.packages()` calls in workflows with `required-packages`
- Use `pkgbuild` instead of `devtools` for binary building in R-CMD-check
- Use `pak::local_install()` instead of `devtools::install()` in pkgdown
- Update `codecov-action` v4 → v5
- Fix `update-renv-lockfile` workflow: add `renv::restore()` before `renv::update()` so CI can detect package updates (empty library meant nothing to update)

These changes preserve the R environment restored from `renv.lock`. Previous ad-hoc `install.packages()` calls could alter the environment by indirectly updating dependencies.

## Usage

```yaml
- uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
  with:
    required-packages: |
      rcmdcheck
      pkgbuild
```

For renv projects, packages must be in `renv.lock`. If missing, the workflow fails with instructions:
```
Required packages not installed: 'covr'
This project uses renv. To fix, run locally:
  1. Add 'covr' to 'Suggests' in DESCRIPTION
  2. renv::install(c("covr"))
  3. renv::snapshot()
  4. Commit the updated renv.lock
```