### PR TITLE
Fix renv update workflow: restore library before updating

### DIFF
--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Install renv
         run: Rscript -e "install.packages('renv')"
 
+      - name: Restore renv library
+        run: Rscript -e "renv::restore()"
+
       - name: Update packages at latest versions and snapshot
         run: Rscript -e "renv::update(lock = TRUE)"
 


### PR DESCRIPTION
## Summary
- Restore renv library before running `renv::update()` to ensure packages are available for update comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI/CD workflow to improve R package environment management during dependency lockfile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->