### PR TITLE
Fix codecov-action@v5 input names

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -56,8 +56,8 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Fix invalid inputs in `test-coverage.yaml` for codecov-action@v5
- `file` → `files`
- `plugin` → `plugins`

Resolves warning: `Unexpected input(s) 'file', 'plugin'`
