### PR TITLE
Fix version bump triggering on workflow_dispatch

### DIFF
--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   detect-changes:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push'
     concurrency: #prevent concurrent runs
       group: ${{ github.workflow }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Changed `detect-changes` condition from `!= 'pull_request'` to `== 'push'`
- Version bump now only runs on actual pushes, not manual workflow dispatches

## Problem
On `workflow_dispatch`, `tj-actions/changed-files` compares HEAD vs HEAD~1. So it incorrectly triggers another bump.