### PR TITLE
Improve renv lockfile update workflow

### DIFF
--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -37,6 +37,7 @@ jobs:
         shell: Rscript {0}
         run: |
           renv::install(prompt = FALSE, lock = TRUE)
+          renv::update(prompt = FALSE, lock = TRUE)
 
       - name: Show renv.lock diff
         run: |

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -36,8 +36,7 @@ jobs:
       - name: Update project dependencies and snapshot lockfile
         shell: Rscript {0}
         run: |
-          renv::install(prompt = FALSE)
-          renv::snapshot(prompt = FALSE)
+          renv::install(prompt = F, lock = T)
 
       - name: Check if renv.lock changed
         id: check-changes

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -36,26 +36,62 @@ jobs:
       - name: Update project dependencies and snapshot lockfile
         shell: Rscript {0}
         run: |
-          renv::install(prompt = FALSE, lock = TRUE)
-          renv::update(prompt = FALSE, lock = TRUE, all = TRUE)
+          repos <- c(PPM = "https://packagemanager.posit.co/cran/latest")
+          options(repos = repos)
 
-      - name: Show renv.lock diff
-        run: |
-          if [ -z "$(git status --porcelain -- renv.lock)" ]; then
-            echo "renv.lock is unchanged."
-          else
-            git --no-pager diff -- renv.lock
-          fi
+          if (file.exists("renv.lock")) {
+            unlink("renv.lock")
+          }
+
+          snapshot_type <- renv::settings$snapshot.type()
+          dev <- renv::settings$snapshot.dev()
+          fields <- renv::settings$package.dependency.fields()
+          install_fields <- if (isTRUE(dev)) unique(c(fields, "Suggests")) else fields
+
+          renv::install(
+            dependencies = install_fields,
+            repos = repos,
+            prompt = FALSE,
+            lock = FALSE
+          )
+
+          candidate <- renv::snapshot(
+            type = snapshot_type,
+            dev = dev,
+            repos = repos,
+            lockfile = NULL,
+            prompt = FALSE,
+            force = TRUE
+          )
+
+          packages <- names(candidate$Packages)
+          if (length(packages) > 0L) {
+            renv::update(
+              packages = packages,
+              all = TRUE,
+              prompt = FALSE,
+              lock = FALSE
+            )
+          }
+
+          renv::snapshot(
+            type = snapshot_type,
+            dev = dev,
+            repos = repos,
+            prompt = FALSE,
+            force = TRUE
+          )
 
       - name: Check if renv.lock changed
         id: check-changes
         run: |
           if [ -z "$(git status --porcelain -- renv.lock)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "renv.lock is unchanged, skipping downstream jobs."
+            echo "renv.lock is unchanged."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "renv.lock has been updated."
+            echo "renv.lock has been updated:"
+            git --no-pager diff -- renv.lock
           fi
 
       - name: Upload updated renv.lock

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -6,6 +6,11 @@ on:
       app-id:
         type: string
         required: true
+      os-matrix:
+        description: 'JSON array of {os, r} objects for the check matrix. Defaults to all three platforms with R release.'
+        required: false
+        type: string
+        default: '[{"os": "windows-latest", "r": "release"}, {"os": "ubuntu-latest", "r": "release"}, {"os": "macos-latest", "r": "release"}]'
     secrets:
       private-key:
         required: true
@@ -108,12 +113,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
-    name: Test on ${{ matrix.os }}
+        config: ${{ fromJSON(inputs.os-matrix) }}
+    runs-on: ${{ matrix.config.os }}
+    name: Test on ${{ matrix.config.os }} (${{ matrix.config.r }})
     env:
       GITHUB_PAT: ${{ github.token }}
 
@@ -130,6 +132,7 @@ jobs:
       - name: Setup R environment
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
+          r-version: ${{ matrix.config.r }}
           setup-pandoc: 'true'
           extra-packages: |
             rcmdcheck

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -36,7 +36,15 @@ jobs:
       - name: Update project dependencies and snapshot lockfile
         shell: Rscript {0}
         run: |
-          renv::install(prompt = F, lock = T)
+          renv::install(prompt = FALSE, lock = TRUE)
+
+      - name: Show renv.lock diff
+        run: |
+          if [ -z "$(git status --porcelain -- renv.lock)" ]; then
+            echo "renv.lock is unchanged."
+          else
+            git --no-pager diff -- renv.lock
+          fi
 
       - name: Check if renv.lock changed
         id: check-changes

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -37,7 +37,7 @@ jobs:
         shell: Rscript {0}
         run: |
           renv::install(prompt = FALSE, lock = TRUE)
-          renv::update(prompt = FALSE, lock = TRUE)
+          renv::update(prompt = FALSE, lock = TRUE, all = TRUE)
 
       - name: Show renv.lock diff
         run: |

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -14,6 +14,8 @@ jobs:
   update-renv-lock:
     runs-on: ubuntu-latest
     name: Update renv.lock
+    env:
+      GITHUB_PAT: ${{ github.token }}
     outputs:
       lockfile-changed: ${{ steps.check-changes.outputs.changed }}
 
@@ -27,18 +29,20 @@ jobs:
           use-public-rspm: true
 
       - name: Install renv
-        run: Rscript -e "install.packages('renv')"
+        shell: Rscript {0}
+        run: |
+          install.packages("renv")
 
-      - name: Restore renv library
-        run: Rscript -e "renv::restore()"
-
-      - name: Update packages at latest versions and snapshot
-        run: Rscript -e "renv::update(lock = TRUE)"
+      - name: Update project dependencies and snapshot lockfile
+        shell: Rscript {0}
+        run: |
+          renv::install(prompt = FALSE)
+          renv::snapshot(prompt = FALSE)
 
       - name: Check if renv.lock changed
         id: check-changes
         run: |
-          if git diff --quiet renv.lock; then
+          if [ -z "$(git status --porcelain -- renv.lock)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "renv.lock is unchanged, skipping downstream jobs."
           else
@@ -66,6 +70,8 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     name: Test on ${{ matrix.os }}
+    env:
+      GITHUB_PAT: ${{ github.token }}
 
     steps:
       - name: Checkout repository
@@ -81,6 +87,8 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           setup-pandoc: 'true'
+          extra-packages: |
+            rcmdcheck
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/


### PR DESCRIPTION
## Summary
- update renv.lock by installing current project dependencies instead of restoring the existing lockfile first
- snapshot the resolved library with project-controlled renv settings
- expose the default Actions token as GITHUB_PAT for GitHub Remotes during update and test jobs
- ensure rcmdcheck is available for the matrix check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency management workflow in the CI/CD pipeline
  * Updated development environment configuration to refine tracking of project artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->