### PR TITLE
Simplify renv lockfile update workflow

### DIFF
--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -14,6 +14,8 @@ jobs:
   update-renv-lock:
     runs-on: ubuntu-latest
     name: Update renv.lock
+    env:
+      GITHUB_PAT: ${{ github.token }}
     outputs:
       lockfile-changed: ${{ steps.check-changes.outputs.changed }}
 
@@ -26,24 +28,22 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install renv
-        run: Rscript -e "install.packages('renv')"
-
-      - name: Restore renv library
-        run: Rscript -e "renv::restore()"
-
-      - name: Update packages at latest versions and snapshot
-        run: Rscript -e "renv::update(lock = TRUE)"
+      - name: Update project dependencies and snapshot lockfile
+        shell: Rscript {0}
+        run: |
+          install.packages("renv")
+          renv::install(prompt = FALSE, lock = TRUE)
 
       - name: Check if renv.lock changed
         id: check-changes
         run: |
-          if git diff --quiet renv.lock; then
+          if [ -z "$(git status --porcelain -- renv.lock)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "renv.lock is unchanged, skipping downstream jobs."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "renv.lock has been updated."
+            git diff renv.lock
           fi
 
       - name: Upload updated renv.lock
@@ -66,6 +66,8 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     name: Test on ${{ matrix.os }}
+    env:
+      GITHUB_PAT: ${{ github.token }}
 
     steps:
       - name: Checkout repository
@@ -81,6 +83,8 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           setup-pandoc: 'true'
+          extra-packages: |
+            rcmdcheck
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -6,6 +6,11 @@ on:
       app-id:
         type: string
         required: true
+      os-matrix:
+        description: 'JSON array of OS names for the test matrix. Defaults to all three platforms.'
+        required: false
+        type: string
+        default: '["windows-latest", "ubuntu-latest", "macos-latest"]'
     secrets:
       private-key:
         required: true
@@ -60,10 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
-          - macos-latest
+        os: ${{ fromJSON(inputs.os-matrix) }}
     runs-on: ${{ matrix.os }}
     name: Test on ${{ matrix.os }}
     env:


### PR DESCRIPTION
## Summary

- Use `renv::install(lock = TRUE)` to install project dependencies and update the lockfile in one step, ignoring the existing lockfile and getting latest available versions
- Make the test matrix configurable via `os-matrix` input (defaults to all three platforms)

## Context

The previous approach could fail when packages recorded in the lockfile were no longer available (e.g., S7 removed from CRAN). By using `renv::install()` without respecting the existing lockfile, we always get the latest available versions from PPM.

Cross-platform validation in `test-on-platforms` ensures the lockfile is only committed if restore succeeds on all platforms.

Succesful run: https://github.com/Felixmil/OSPSuite-R/actions/runs/24889058944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced customizable OS matrix input for testing workflow, enabling selection of specific operating systems (Windows, Ubuntu, macOS) to test against.

* **Improvements**
  * Enhanced R environment configuration for comprehensive testing.
  * Refined dependency lockfile change detection with improved Git status checking.
  * Updated GitHub API authentication configuration for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->