### PR TITLE
Fix setup-r-env for non-renv projects using extra-packages

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: 'false'
   extra-packages:
-    description: 'CI tool packages (e.g., covr, pkgdown, rcmdcheck) to install before renv restore. Gets latest version; if package is in renv.lock, restore will overwrite with locked version.'
+    description: 'CI tool packages (e.g., covr, pkgdown, rcmdcheck). For renv projects, installed before renv restore (latest version; restore overwrites if package is in renv.lock). For non-renv projects, forwarded to setup-r-dependencies.'
     required: false
     default: ''
 
@@ -76,8 +76,8 @@ runs:
       run: echo "renv_detected=$([ -f renv.lock ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Install extra packages
-      if: inputs.extra-packages != ''
+    - name: Install extra packages (renv projects)
+      if: inputs.extra-packages != '' && steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
       shell: Rscript {0}
       env:
         EXTRA_PACKAGES: ${{ inputs.extra-packages }}
@@ -85,7 +85,18 @@ runs:
         pkgs <- strsplit(Sys.getenv("EXTRA_PACKAGES"), "\\s+")[[1]]
         pkgs <- pkgs[nzchar(pkgs)]
         if (length(pkgs) > 0L) {
-          install.packages("pak")
+          # Install pak from r-lib's prebuilt binary repo to avoid source
+          # compilation when no CRAN/RSPM binary is yet available (e.g. days
+          # after a new R release).
+          install.packages(
+            "pak",
+            repos = sprintf(
+              "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+              .Platform$pkgType,
+              R.Version()$os,
+              R.Version()$arch
+            )
+          )
           pak::pkg_install(pkgs)
         }
 
@@ -124,3 +135,5 @@ runs:
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'
       uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        extra-packages: ${{ inputs.extra-packages }}


### PR DESCRIPTION
## Summary

The `Install extra packages` step in `setup-r-env` ran unconditionally whenever `extra-packages` was set, and called `install.packages(\"pak\")`. On runners with no pak binary available (e.g. shortly after a new R release, where RSPM/CRAN haven't published binaries yet), this falls back to source compilation — which fails when system libraries like `libcurl4-openssl-dev` aren't installed. Observed in [esqlabsR PR #1006](https://github.com/esqLABS/esqlabsR/actions/runs/25043185196/job/73351356101?pr=1006) where R 4.6.0 + Ubuntu produced `there is no package called 'pak'` after `Compilation failed.`.

## Changes

- Non-renv projects: `extra-packages` is now forwarded to `r-lib/actions/setup-r-dependencies@v2`, which uses pak via its prebuilt-binary repo and handles installation correctly.
- Renv projects: the dedicated install step is now gated on `renv_detected == 'true' && ignore-renv != 'true'`, and installs pak from `https://r-lib.github.io/p/pak/stable/...` (pak's official prebuilt-binary repo) so source compilation is avoided.

The renv-only constraint is preserved: extras for renv projects are still installed before renv setup, outside the renv library, so renv remains the sole package source for project deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `extra-packages` input handling to properly distinguish between renv-backed and non-renv projects, ensuring correct package installation behavior for each project type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->