### PR TITLE
Expose quarto/pandoc/tinytex/extra-packages inputs on R-CMD-check-build

### DIFF
--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -18,6 +18,26 @@ on:
         required: false
         type: boolean
         default: true
+      setup-quarto:
+        description: 'Whether to install Quarto (needed for packages with Quarto vignettes).'
+        required: false
+        type: boolean
+        default: false
+      setup-pandoc:
+        description: 'Whether to install pandoc.'
+        required: false
+        type: boolean
+        default: true
+      setup-tinytex:
+        description: 'Whether to install TinyTeX (provides pdflatex for PDF manual builds).'
+        required: false
+        type: boolean
+        default: false
+      extra-packages:
+        description: 'Additional CI tool packages to install, on top of rcmdcheck (and pkgbuild when build-binary is true). One package per line.'
+        required: false
+        type: string
+        default: ''
 name: R-CMD-check
 
 permissions: read-all
@@ -47,12 +67,14 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           r-version: ${{ matrix.config.r }}
-          setup-pandoc: 'true'
-          setup-tinytex: 'false'
+          setup-pandoc: ${{ inputs.setup-pandoc }}
+          setup-tinytex: ${{ inputs.setup-tinytex }}
+          setup-quarto: ${{ inputs.setup-quarto }}
           ignore-renv: ${{ inputs.ignore-renv }}
           extra-packages: |
             rcmdcheck
             ${{ inputs.build-binary && 'pkgbuild' || '' }}
+            ${{ inputs.extra-packages }}
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
## Summary
- Add `setup-quarto`, `setup-pandoc`, `setup-tinytex`, and `extra-packages` inputs to the reusable `R-CMD-check-build.yaml` workflow.
- Forward them to `setup-r-env`, replacing the previously hardcoded `setup-pandoc: 'true'` / `setup-tinytex: 'false'`.
- `extra-packages` is appended to the existing `rcmdcheck` (+ optional `pkgbuild`) defaults so callers can add project-specific CI tools without losing them.

## Motivation
Packages with Quarto vignettes need Quarto on the runner. The underlying `setup-r-env` action already supports `setup-quarto`, but the reusable workflow didn't expose it. Same applies to pandoc/tinytex toggles and extra CI packages.

Defaults preserve current behavior: `setup-pandoc=true`, `setup-tinytex=false`, `setup-quarto=false`, `extra-packages=''`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow now supports configurable optional tool setup and additional package dependencies.
  * Updated repository ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->