### PR TITLE
Support protected branches in description-manager

### DIFF
--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -114,5 +114,5 @@ jobs:
         if: inputs.build-binary
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.PKG_NAME }}-v${{ env.PKG_VERSION }}-${{runner.os}}-r_${{ env.R_VERSION }}
+          name: ${{ env.PKG_NAME }}-v${{ env.PKG_VERSION }}-${{ matrix.config.os }}-r_${{ env.R_VERSION }}
           path: ${{ runner.temp }}/built_package/*

--- a/.github/workflows/bump_dev_version_tag_branch.yaml
+++ b/.github/workflows/bump_dev_version_tag_branch.yaml
@@ -2,17 +2,20 @@
 # DEPRECATED: This workflow now delegates to description_manager.yaml.
 #
 # Why: description_manager.yaml does the same thing (bump dev version, toggle
-# @*release in Remotes, tag releases) without the GitHub-App-token machinery,
-# uses a tested helper script, and reports a richer step summary.
+# @*release in Remotes, tag releases), uses a tested helper script, and reports
+# a richer step summary.
 #
 # Migration: change your caller from
 #   uses: Open-Systems-Pharmacology/Workflows/.github/workflows/bump_dev_version_tag_branch.yaml@<ref>
 # to
 #   uses: Open-Systems-Pharmacology/Workflows/.github/workflows/description_manager.yaml@<ref>
-# and drop the `app-id` / `private-key` inputs.
+# Keep forwarding `app-id` / `private-key` only if the target branch is
+# protected; otherwise the defaults (GITHUB_TOKEN) are sufficient and the
+# inputs can be dropped.
 #
-# This shim keeps the old API alive (inputs and secret remain accepted but are
-# ignored) so existing callers continue to work.
+# This shim keeps the old API alive: `app-id` / `private-key` are forwarded to
+# description_manager.yaml so existing callers continue to push to protected
+# branches without changes.
 name: bump-dev-version
 
 on:
@@ -32,10 +35,14 @@ jobs:
     steps:
       - name: Emit deprecation warning
         run: |
-          echo "::warning title=Deprecated workflow::bump_dev_version_tag_branch.yaml is deprecated. Migrate callers to .github/workflows/description_manager.yaml — the app-id input and private-key secret are no longer needed."
+          echo "::warning title=Deprecated workflow::bump_dev_version_tag_branch.yaml is deprecated. Migrate callers to .github/workflows/description_manager.yaml. Keep forwarding app-id / private-key only when pushing to a protected branch."
 
   delegate:
     needs: deprecation-notice
     uses: ./.github/workflows/description_manager.yaml
     permissions:
       contents: write
+    with:
+      app-id: ${{ inputs.app-id }}
+    secrets:
+      private-key: ${{ secrets.private-key }}

--- a/.github/workflows/description_manager.yaml
+++ b/.github/workflows/description_manager.yaml
@@ -15,6 +15,15 @@ on:
         type: string
         required: false
         default: 'main'
+      app-id:
+        description: |
+          GitHub App ID used to mint a push token. Required when the target
+          branch is protected and the App's identity is in the ruleset's
+          bypass list. Leave empty to fall back to GITHUB_TOKEN (sufficient
+          for unprotected branches).
+        type: string
+        required: false
+        default: ''
       tracked-files:
         description: |
           Newline-separated glob patterns of files whose changes should trigger
@@ -40,6 +49,12 @@ on:
           data-raw/**
           src/**
           shared/**
+    secrets:
+      private-key:
+        description: |
+          Private key (PEM) for the GitHub App referenced by `app-id`. Required
+          together with `app-id` when pushing to a protected branch.
+        required: false
 
 jobs:
   detect-changes:
@@ -102,10 +117,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: inputs.app-id != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+
       - name: Checkout caller repo
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Checkout Workflows repo (for helper scripts)
         uses: actions/checkout@v6

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Generate token from GitHub App
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}


### PR DESCRIPTION
Allow the `description-manager` reusable workflow to push to branches with rulesets / protection by minting a token from a GitHub App, while keeping the existing `GITHUB_TOKEN` path the default for unprotected branches. Restores the App-token capability that the deprecated `bump_dev_version_tag_branch.yaml` had before it became a shim.

## description-manager

Two new opt-in entry points on `workflow_call`, both optional:

- Input `app-id` (string, defaults to `''`): GitHub App ID used to mint a push token.
- Secret `private-key`: PEM private key for that App.

When `app-id` is empty (the default), nothing changes: the token-minting step is skipped, `actions/checkout` falls back to `GITHUB_TOKEN`, and `stefanzweifel/git-auto-commit-action` pushes as before. When `app-id` is set, `actions/create-github-app-token@v3` produces a short-lived installation token and `checkout` uses it, so subsequent pushes carry the App's identity (which the org can put in the branch ruleset's bypass list).

## bump_dev_version_tag_branch (shim)

The deprecation shim now forwards `app-id` / `private-key` to the delegated workflow instead of dropping them. The deprecation notice is reworded: the inputs are no longer flagged as "no longer needed", they're only required when the caller pushes to a protected branch.

## update-renv-lockfile

Bumped `actions/create-github-app-token` from `v1` to `v3` for consistency with the new call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows: deprecated a legacy shim that now delegates to the reusable description manager.
  * Reusable description workflow: added optional parameters to support minting a GitHub App push token for protected branches and forwarding credentials when provided.
  * Bumped token-generation action version and adjusted artifact naming in build checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/Workflows/pull/227)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->