### PR TITLE
Expose dotnet-version input; install .NET on all runners

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -46,10 +46,6 @@ outputs:
 runs:
   using: composite
   steps:
-    # Install on every runner, not just macOS. GitHub-hosted Linux and Windows
-    # images do ship some .NET SDK versions preinstalled, but they lag behind
-    # current majors (e.g. no .NET 10 yet as of early 2026), so consumers that
-    # load assemblies targeting newer TFMs need an explicit install.
     - name: Setup .NET
       if: inputs.dotnet-version != ''
       uses: actions/setup-dotnet@v5

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'false'
   dotnet-version:
-    description: '.NET version to install on macOS (e.g. "8.0.x", "9.0.x")'
+    description: '.NET SDK version to install on all runners (e.g. "8.0.x", "10.0.x"). Set to an empty string to skip the setup-dotnet step.'
     required: false
     default: '8.0.x'
   ignore-renv:
@@ -46,8 +46,12 @@ outputs:
 runs:
   using: composite
   steps:
+    # Install on every runner, not just macOS. GitHub-hosted Linux and Windows
+    # images do ship some .NET SDK versions preinstalled, but they lag behind
+    # current majors (e.g. no .NET 10 yet as of early 2026), so consumers that
+    # load assemblies targeting newer TFMs need an explicit install.
     - name: Setup .NET
-      if: runner.os == 'macOS'
+      if: inputs.dotnet-version != ''
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'false'
   dotnet-version:
-    description: '.NET SDK version to install on all runners (e.g. "8.0.x", "10.0.x"). Set to an empty string to skip the setup-dotnet step.'
+    description: '.NET SDK version to install on all runners (e.g. "8.0.x", "10.0.x"). Set to an empty string to skip the setup-dotnet step and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
     required: false
     default: '8.0.x'
   ignore-renv:

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -42,7 +42,7 @@ on:
         type: string
         default: ''
       dotnet-version:
-        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet.'
+        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
         required: false
         type: string
         default: '8.0.x'

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ''
+      dotnet-version:
+        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet.'
+        required: false
+        type: string
+        default: '8.0.x'
 name: R-CMD-check
 
 permissions: read-all
@@ -74,6 +79,7 @@ jobs:
           setup-tinytex: ${{ inputs.setup-tinytex }}
           setup-quarto: ${{ inputs.setup-quarto }}
           ignore-renv: ${{ inputs.ignore-renv }}
+          dotnet-version: ${{ inputs.dotnet-version }}
           extra-packages: |
             rcmdcheck
             ${{ inputs.build-binary && 'pkgbuild' || '' }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,7 +9,7 @@ on:
         type: boolean
         default: false
       dotnet-version:
-        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet.'
+        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
         required: false
         type: string
         default: '8.0.x'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      dotnet-version:
+        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet.'
+        required: false
+        type: string
+        default: '8.0.x'
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -32,6 +37,7 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           ignore-renv: ${{ inputs.ignore-renv }}
+          dotnet-version: ${{ inputs.dotnet-version }}
           extra-packages: covr
 
       - name: Test coverage


### PR DESCRIPTION
## Summary

`setup-r-env` previously only invoked `actions/setup-dotnet` on macOS, and neither `R-CMD-check-build.yaml` nor `test-coverage.yaml` exposed a `dotnet-version` input — leaving consumers with no way to ask for a newer .NET SDK on Linux/Windows. Works fine while everyone targets whatever ships on the runner image (8.x today). Breaks the moment any consumer's `inst/lib` payload targets a newer TFM: `R CMD check` fails at load time with `ReflectionTypeLoadException`.

Concretely this is blocking [OSPSuite-R#1941](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/pull/1941), which retargets the DependencyManager and its `inst/lib` to net10.0.

## Changes

- **`setup-r-env/action.yml`** — drop the `runner.os == 'macOS'` guard; gate the step on `dotnet-version != ''` instead. Default stays `'8.0.x'`, so:
  - Existing consumers: macOS still gets 8.0.x as before. Linux/Windows now also get an explicit `setup-dotnet` call. Since 8.x already ships on those images, this is a cache-hit no-op (a few seconds in the worst case).
  - Consumers who want to opt out can pass `dotnet-version: ''`.
- **`R-CMD-check-build.yaml`** — add a `dotnet-version` workflow input (default `'8.0.x'`) and forward it to `setup-r-env`.
- **`test-coverage.yaml`** — same.

## Compatibility

Backward-compatible by default. No caller needs to change anything unless they want to override the SDK version. The only behaviour change for existing callers is the explicit Linux/Windows `setup-dotnet` step — which is a near-no-op against pre-installed 8.x.

## Test plan

- [ ] OSPSuite-R PR ([#1941](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/pull/1941)) passes R-CMD-Check on all three OSes after pointing at this branch and passing `dotnet-version: '10.0.x'`
- [ ] Some other consumer (e.g. esqlabsR, MoBi-R) still passes without any caller changes — confirms the default behaviour didn't regress
- [ ] `dotnet-version: ''` cleanly skips the setup-dotnet step (visual log inspection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced CI/CD infrastructure to support flexible .NET SDK version configuration across all automated pipelines and workflows, enabling individual builds to specify custom .NET SDK versions or completely skip the .NET setup step when not required. This improves overall pipeline configuration flexibility and reduces unnecessary build overhead and setup time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/Workflows/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->