### PR TITLE
Add Dependency review on pull request

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+# Dependency review action following the description in:
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configuring-the-dependency-review-action
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v6
+    - name: Dependency Review
+      uses: actions/dependency-review-action@v5
+      with:
+        # Possible values: "critical", "high", "moderate", "low"
+        fail-on-severity: high
+
+        comment-summary-in-pr: on-failure
+        show-patched-versions: true
+        
+        # Skip these GitHub Advisory Database IDs during detection (optional)
+        # Possible values: Any valid GitHub Advisory Database ID from https://github.com/advisories
+        # allow-ghsas: GHSA-abcd-1234-5679, GHSA-efgh-1234-5679

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      license-check:
+        description: 'Enable or disable the license check performed by the action.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -44,3 +49,4 @@ jobs:
         comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
         show-patched-versions: ${{ inputs.show-patched-versions }}
         allow-ghsas: ${{ inputs.allow-ghsas }}
+        license-check: ${{ inputs.license-check }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,31 @@
 name: Dependency Review
 # Dependency review action following the description in:
 # https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configuring-the-dependency-review-action
+# Should be called on pull_request by the caller
 
-on: pull_request
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: 'Possible values: "critical", "high", "moderate", "low"'
+        required: false
+        type: string
+        default: 'high'
+      comment-summary-in-pr:
+        description: 'Possible values: "always", "on-failure", "never"'
+        required: false
+        type: string
+        default: 'on-failure'
+      show-patched-versions:
+        description: 'When set to true, the vulnerability summary table will include an additional column showing the first patched version for each vulnerability. This requires additional API calls to fetch advisory data.'
+        required: false
+        type: boolean
+        default: true
+      allow-ghsas:
+        description: 'List of GitHub Advisory Database (https://github.com/advisories) IDs that can be skipped, separated by comma, e.g. "GHSA-1234, GHSA-5678"'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -17,12 +40,7 @@ jobs:
     - name: Dependency Review
       uses: actions/dependency-review-action@v5
       with:
-        # Possible values: "critical", "high", "moderate", "low"
-        fail-on-severity: high
-
-        comment-summary-in-pr: on-failure
-        show-patched-versions: true
-        
-        # Skip these GitHub Advisory Database IDs during detection (optional)
-        # Possible values: Any valid GitHub Advisory Database ID from https://github.com/advisories
-        # allow-ghsas: GHSA-abcd-1234-5679, GHSA-efgh-1234-5679
+        fail-on-severity: ${{ inputs.fail-on-severity }}
+        comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
+        show-patched-versions: ${{ inputs.show-patched-versions }}
+        allow-ghsas: ${{ inputs.allow-ghsas }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
     - name: 'Checkout Repository'
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Dependency Review
       uses: actions/dependency-review-action@v5
       with:

--- a/.github/workflows/dependency-review_on_PR.yml
+++ b/.github/workflows/dependency-review_on_PR.yml
@@ -1,0 +1,12 @@
+name: Dependency Review
+# Dependency review action following the description in:
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    uses: ./.github/workflows/dependency-review.yml

--- a/.github/workflows/dependency-review_on_PR.yml
+++ b/.github/workflows/dependency-review_on_PR.yml
@@ -10,3 +10,5 @@ permissions:
 jobs:
   dependency-review:
     uses: ./.github/workflows/dependency-review.yml
+    with:
+      comment-summary-in-pr: 'always'


### PR DESCRIPTION
Checks the dependencies added/modified in a PR (details s. https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configuring-the-dependency-review-action)

Adds review comment to a PR (like [here](https://github.com/Yuri05/Workflows/pull/5#issuecomment-4508002257)) and fails if any vulnerabilities are detected.

My initial idea was to apply this globally to the organization via a ruleset (as described in https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/configure-specific-tools/enforcing-dependency-review-across-an-organization). 

Unfortunately, organization rulesets do not work on free GitHub plans, so it can be done only repo by repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated dependency review workflow for pull requests with configurable severity thresholds, optional license validation, and flexible reporting behavior in PR comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/Workflows/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->