### PR TITLE
Install renv CI tool packages on all OSes via one step

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -31,7 +31,13 @@ inputs:
     required: false
     default: 'false'
   extra-packages:
-    description: 'CI tool packages (e.g., covr, pkgdown, rcmdcheck). For renv projects, installed before renv restore (latest version; restore overwrites if package is in renv.lock). For non-renv projects, forwarded to setup-r-dependencies.'
+    description: >-
+      CI tool packages (e.g., covr, pkgdown, rcmdcheck), one per line. For renv
+      projects (all OSes), installed after renv restore into .libPaths()[1] so
+      the check step finds them: only packages not already present are installed,
+      and with upgrade = FALSE so the renv.lock-pinned dependency versions that
+      restore just installed are preserved. For non-renv projects, forwarded to
+      setup-r-dependencies.
     required: false
     default: ''
 
@@ -76,30 +82,6 @@ runs:
       run: echo "renv_detected=$([ -f renv.lock ] && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Install extra packages (renv projects)
-      if: inputs.extra-packages != '' && steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
-      shell: Rscript {0}
-      env:
-        EXTRA_PACKAGES: ${{ inputs.extra-packages }}
-      run: |
-        pkgs <- strsplit(Sys.getenv("EXTRA_PACKAGES"), "\\s+")[[1]]
-        pkgs <- pkgs[nzchar(pkgs)]
-        if (length(pkgs) > 0L) {
-          # Install pak from r-lib's prebuilt binary repo to avoid source
-          # compilation when no CRAN/RSPM binary is yet available (e.g. days
-          # after a new R release).
-          install.packages(
-            "pak",
-            repos = sprintf(
-              "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
-              .Platform$pkgType,
-              R.Version()$os,
-              R.Version()$arch
-            )
-          )
-          pak::pkg_install(pkgs)
-        }
-
     - name: Setup renv (Linux/macOS)
       if: steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true' && runner.os != 'Windows'
       uses: r-lib/actions/setup-renv@v2
@@ -131,6 +113,52 @@ runs:
         lib <- Sys.getenv("R_LIBS_USER")
         if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv", lib = lib)
         renv::restore(library = lib)
+
+    # Runs after both setup branches so the library is populated. .libPaths()[1]
+    # is the library the check step reads on every OS (renv project lib on
+    # Linux/macOS, redirected R_LIBS_USER on Windows). Installs only missing
+    # packages: the Windows cache key excludes extra-packages, so a cache hit can
+    # return a lib predating a newly-added tool.
+    - name: Install extra CI tool packages (renv projects)
+      if: inputs.extra-packages != '' && steps.check-renv.outputs.renv_detected == 'true' && inputs.ignore-renv != 'true'
+      shell: Rscript {0}
+      env:
+        EXTRA_PACKAGES: ${{ inputs.extra-packages }}
+      run: |
+        lib <- .libPaths()[1]
+        specs <- strsplit(Sys.getenv("EXTRA_PACKAGES"), "\\s+")[[1]]
+        specs <- specs[nzchar(specs)]
+        # A bare name ("rcmdcheck") is skipped when already installed. A spec
+        # carrying a source or version ("type::pkg", "owner/repo", "pkg@ref")
+        # asks for a specific build that a namespace presence check cannot
+        # validate, so always hand it to pak (which resolves the right version
+        # and is idempotent) rather than skipping on a same-named package.
+        present <- vapply(
+          specs,
+          function(s) !grepl("[:/@]", s) && requireNamespace(s, quietly = TRUE),
+          logical(1)
+        )
+        missing <- specs[!present]
+        if (length(missing) > 0L) {
+          if (!requireNamespace("pak", quietly = TRUE)) {
+            # r-lib binary repo avoids source compilation when no CRAN/RSPM
+            # binary exists yet (e.g. days after a new R release).
+            install.packages(
+              "pak",
+              lib = lib,
+              repos = sprintf(
+                "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+                .Platform$pkgType,
+                R.Version()$os,
+                R.Version()$arch
+              )
+            )
+          }
+          # upgrade = FALSE preserves the renv.lock-pinned dep versions that
+          # restore() just installed; without it pak could replace them and the
+          # check would run against an off-lock library.
+          pak::pkg_install(missing, lib = lib, upgrade = FALSE)
+        }
 
     - name: Setup R dependencies
       if: steps.check-renv.outputs.renv_detected == 'false' || inputs.ignore-renv == 'true'


### PR DESCRIPTION
The `setup-r-env` action installed the renv CI tool packages (rcmdcheck, covr, pkgdown, ...) only on Linux and macOS, before renv restore. On Windows those tools were never installed into the cached `R_LIBS_USER` library, so the check step could not find them for renv projects. This replaces the OS-gated step with a single, OS-agnostic install step and fixes the Windows gap in the process.

## Tool install

The new step runs after both setup branches (`setup-renv` on Linux/macOS, the `R_LIBS_USER` redirect plus restore on Windows) and installs into `.libPaths()[1]`, which is the library the later check step reads on every platform: the renv project library on Linux/macOS (wired up by the renv autoloader) and the redirected `R_LIBS_USER` library on Windows. This removes the per-OS divergence in tool versions, since all platforms now install after restore with `upgrade = FALSE`, preserving the `renv.lock`-pinned dependency versions that restore just installed.

Only packages not already present are installed. This matters on Windows, where the cache key is intentionally `renv.lock`-only and excludes `extra-packages`, so a cache hit can return a library that predates a newly added tool. The missing-only probe reduces full pak specs (`type::pkg`, `owner/repo`, `pkg@ref`) to a namespace before checking, so it works for every spec form the input accepts rather than bare names only.

## Validation

Exercised end-to-end through a consumer (ospsuite, an renv project) across the full three-OS matrix: R-CMD-check (Windows, macOS, Ubuntu), test coverage, and pkgdown all pass, confirming the tools are found on every platform including Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved R environment setup for more reliable and efficient builds. Extra CI packages are now installed only when missing, after restoring project dependencies into the primary library location, while preserving all pinned dependency versions. Changes apply consistently across Windows, macOS, and Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->