### PR TITLE
Install pinned .NET runtime so net8 rSharp stays off .NET 10 on Windows CI

### DIFF
--- a/.github/actions/setup-dotnet-runtime/action.yml
+++ b/.github/actions/setup-dotnet-runtime/action.yml
@@ -1,0 +1,92 @@
+name: 'Setup .NET runtime'
+description: >-
+  Installs a pinned .NET shared runtime (not the SDK) via Microsoft's
+  dotnet-install script and pins roll-forward, so a net8-targeted process
+  (e.g. rSharp) runs on the runtime it was built for and never rolls forward
+  to a higher major such as .NET 10.
+
+inputs:
+  dotnet-version:
+    description: >-
+      .NET runtime version to install. Accepts a channel ("8.0.x", "10.0.x",
+      "8.0"), a bare major ("8", "10"), or an exact runtime version ("8.0.18").
+      Set to an empty string to skip installation entirely and use whatever the
+      runner image ships with (which may be no .NET at all, e.g. on macOS).
+    required: false
+    default: '8.0.x'
+
+runs:
+  using: composite
+  steps:
+    # Why not actions/setup-dotnet@v5: it unconditionally runs the install
+    # script with `-Runtime dotnet -Channel LTS` (LTS == .NET 10 from late
+    # 2025) before installing the requested version, dropping the .NET 10
+    # shared runtime and its host into DOTNET_ROOT alongside the requested one.
+    # rSharp ships net8-targeted assemblies; on Windows the shared muxer then
+    # resolves the newest hostfxr (net10's), so those assemblies run through a
+    # net10 host and segfault (0xC0000005 / exit code -1073741819) the moment a
+    # test calls into .NET.
+    #
+    # dotnet-install does a single install pinned to the requested channel with
+    # no hardcoded LTS step, so .NET 10 never lands unless a caller asks for it.
+    # DOTNET_ROLL_FORWARD=Disable is belt-and-braces: a net8 app then refuses to
+    # bind to any other major even if one is somehow present. The channel is
+    # derived from dotnet-version, so `10.0.x` still provisions net10 unchanged.
+    #
+    # Runtime-only (--runtime dotnet) is sufficient for R package checks: rSharp
+    # ships prebuilt assemblies, so the check step only ever runs .NET, never
+    # builds it. dotnet-install does not touch DOTNET_ROOT/PATH, so we set both.
+    - name: Install .NET runtime (Unix)
+      if: inputs.dotnet-version != '' && runner.os != 'Windows'
+      shell: bash
+      env:
+        DOTNET_VERSION: ${{ inputs.dotnet-version }}
+      run: |
+        set -euo pipefail
+        install_dir="${RUNNER_TEMP}/dotnet"
+        args=(--runtime dotnet --install-dir "${install_dir}" --no-path)
+        # Map the input to a dotnet-install argument:
+        #   "8.0.18" (exact X.Y.Z)     -> --version 8.0.18 (that exact build)
+        #   "8" / "10" (bare major)    -> --channel 8.0 / 10.0
+        #   "8.0.x" / "8.0" (channel)  -> --channel 8.0 (latest patch)
+        # dotnet-install channels are A.B form, so a bare major gains ".0".
+        if [[ "${DOTNET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          args+=(--version "${DOTNET_VERSION}")
+        elif [[ "${DOTNET_VERSION}" =~ ^[0-9]+$ ]]; then
+          args+=(--channel "${DOTNET_VERSION}.0")
+        else
+          args+=(--channel "${DOTNET_VERSION%.x}")
+        fi
+        curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${RUNNER_TEMP}/dotnet-install.sh"
+        bash "${RUNNER_TEMP}/dotnet-install.sh" "${args[@]}"
+        echo "DOTNET_ROOT=${install_dir}" >> "${GITHUB_ENV}"
+        echo "DOTNET_ROLL_FORWARD=Disable" >> "${GITHUB_ENV}"
+        echo "${install_dir}" >> "${GITHUB_PATH}"
+
+    - name: Install .NET runtime (Windows)
+      if: inputs.dotnet-version != '' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        DOTNET_VERSION: ${{ inputs.dotnet-version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $installDir = Join-Path $env:RUNNER_TEMP 'dotnet'
+        $params = @{ Runtime = 'dotnet'; InstallDir = $installDir; NoPath = $true }
+        # Map the input to a dotnet-install argument:
+        #   "8.0.18" (exact X.Y.Z)     -> -Version 8.0.18 (that exact build)
+        #   "8" / "10" (bare major)    -> -Channel 8.0 / 10.0
+        #   "8.0.x" / "8.0" (channel)  -> -Channel 8.0 (latest patch)
+        # dotnet-install channels are A.B form, so a bare major gains ".0".
+        if ($env:DOTNET_VERSION -match '^[0-9]+\.[0-9]+\.[0-9]+$') {
+          $params['Version'] = $env:DOTNET_VERSION
+        } elseif ($env:DOTNET_VERSION -match '^[0-9]+$') {
+          $params['Channel'] = "$($env:DOTNET_VERSION).0"
+        } else {
+          $params['Channel'] = ($env:DOTNET_VERSION -replace '\.x$', '')
+        }
+        $script = Join-Path $env:RUNNER_TEMP 'dotnet-install.ps1'
+        Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile $script
+        & $script @params
+        "DOTNET_ROOT=$installDir"     | Out-File -FilePath $env:GITHUB_ENV  -Append
+        "DOTNET_ROLL_FORWARD=Disable" | Out-File -FilePath $env:GITHUB_ENV  -Append
+        $installDir                   | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -23,7 +23,15 @@ inputs:
     required: false
     default: 'false'
   dotnet-version:
-    description: '.NET SDK version to install on all runners (e.g. "8.0.x", "10.0.x"). Set to an empty string to skip the setup-dotnet step and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
+    description: >-
+      .NET runtime version to install on all runners. Accepts a channel
+      ("8.0.x", "10.0.x", "8.0"), a bare major ("8", "10"), or an exact runtime
+      version ("8.0.18"). The runtime (not the SDK) is installed via
+      Microsoft''s dotnet-install script
+      and pinned with DOTNET_ROLL_FORWARD=Disable, so a net8-targeted process
+      (e.g. rSharp) never rolls forward to a higher major. Set to an empty
+      string to skip .NET setup entirely and use whatever the runner image ships
+      with (which may be no .NET at all, e.g. on macOS).
     required: false
     default: '8.0.x'
   ignore-renv:
@@ -52,9 +60,12 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Setup .NET
+    # Install the pinned .NET runtime (not the SDK) so a net8-targeted process
+    # such as rSharp runs on the runtime it was built for. See the
+    # setup-dotnet-runtime action for why actions/setup-dotnet is not used.
+    - name: Setup .NET runtime
       if: inputs.dotnet-version != ''
-      uses: actions/setup-dotnet@v5
+      uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-dotnet-runtime@main
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -42,7 +42,7 @@ on:
         type: string
         default: ''
       dotnet-version:
-        description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
+        description: '.NET runtime version to install on all runners (forwarded to setup-r-env; a channel like "8.0.x"/"10.0.x", a bare major like "8"/"10", or an exact version). Set to an empty string to skip .NET setup and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
         required: false
         type: string
         default: '8.0.x'

--- a/.github/workflows/verify-dotnet-provisioning.yaml
+++ b/.github/workflows/verify-dotnet-provisioning.yaml
@@ -1,0 +1,55 @@
+# Verification workflow for the setup-dotnet-runtime action.
+#
+# Proves that the action installs the net8 runtime and does NOT drag in the
+# .NET 10 runtime (the segfault cause) on any runner, Windows included. It
+# exercises the action via its local path so a PR tests its own changes. Runs
+# on demand; safe to remove once the fix has been observed green.
+name: Verify .NET provisioning
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/actions/setup-dotnet-runtime/action.yml'
+      - '.github/workflows/verify-dotnet-provisioning.yaml'
+
+permissions: read-all
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET runtime
+        uses: ./.github/actions/setup-dotnet-runtime
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Show DOTNET_ROOT and installed runtimes
+        shell: bash
+        run: |
+          echo "DOTNET_ROOT=${DOTNET_ROOT:-<unset>}"
+          echo "DOTNET_ROLL_FORWARD=${DOTNET_ROLL_FORWARD:-<unset>}"
+          echo "--- dotnet --list-runtimes ---"
+          dotnet --list-runtimes
+
+      - name: Assert net8 present and net10 absent
+        shell: bash
+        run: |
+          runtimes="$(dotnet --list-runtimes)"
+          if echo "$runtimes" | grep -q 'Microsoft.NETCore.App 10\.'; then
+            echo "::error::Microsoft.NETCore.App 10.x is present; the net10 runtime should not be installed."
+            exit 1
+          fi
+          if ! echo "$runtimes" | grep -q 'Microsoft.NETCore.App 8\.'; then
+            echo "::error::Microsoft.NETCore.App 8.x is missing; the net8 runtime must be installed."
+            exit 1
+          fi
+          echo "OK: net8 runtime present, no net10 runtime."


### PR DESCRIPTION
Windows CI intermittently segfaulted during `R CMD check` test runs in downstream OSP R packages that call into .NET through `rSharp` (`SystemRequirements: dotnet8`). A parallel `testthat` worker died with a native access violation (`R session crashed with exit code -1073741819`, i.e. `0xC0000005`) the moment a test invoked the .NET layer; Linux and macOS passed. This changes how `setup-r-env` provisions .NET so a net8-targeted process runs on the .NET 8 runtime and never ends up executing through a .NET 10 host.

## Root cause

`actions/setup-dotnet@v5` does not install only what you ask for. On every invocation it runs the install script twice: first `install-dotnet -Runtime dotnet -Channel LTS`, then the requested version. As of late 2025 the LTS channel resolves to .NET 10, so requesting `8.0.x` still drags the .NET 10 shared runtime (and its host) onto the runner, into the same `DOTNET_ROOT` as net8. The failing job shows both lines plainly:

```
install-dotnet ... -Runtime dotnet -Channel LTS   ->  Installed version is 10.0.10
install-dotnet ... -Channel 8.0                    ->  Installed version is 8.0.423
```

`rSharp` ships assemblies built for `net8.0` and pins `net8.0` in its `runtimeconfig.json` with the default `Minor` roll-forward, which never crosses a major boundary. So it does not "roll forward" to .NET 10. The problem is subtler: the .NET shared muxer resolves `hostfxr` from the highest installed version, so once .NET 10 is present the net8 assemblies get launched through the .NET 10 host. That host/interop skew is what faults natively on Windows. Removing the .NET 10 install removes the mismatched host.

`SystemRequirements: dotnet8` does not help here. `pak`'s system-requirements mechanism only acts on Linux; on Windows and macOS it is a no-op, so the `setup-dotnet` step is the only thing putting .NET on those runners and had to be replaced rather than dropped.

## Fix

A new composite action, `setup-dotnet-runtime`, installs the .NET runtime directly via Microsoft's `dotnet-install` script instead of `actions/setup-dotnet`. It performs a single install pinned to the requested channel, with no hardcoded LTS step, so .NET 10 never lands unless a caller explicitly asks for it. It also exports `DOTNET_ROLL_FORWARD=Disable` as a second line of defense, so a net8 app refuses to bind to any other major even if one is somehow present. `setup-r-env` now calls this action in place of the old `setup-dotnet` step.

The runtime (not the SDK) is installed. That is sufficient for R package checks: `rSharp` ships prebuilt assemblies, so the check step only ever runs .NET, never builds it.

The `dotnet-version` input is unchanged for callers and stays backward compatible. It now accepts a channel (`8.0.x`, `10.0.x`, `8.0`), a bare major (`8`, `10`), or an exact runtime version (`8.0.18`). A caller that wants net10 later can pass `10.0.x` (or `10`) and gets net10, no other change required.

## Verification

`dotnet-install` cannot be exercised locally in a representative way, so verification runs in CI. A new `verify-dotnet-provisioning` workflow exercises `setup-dotnet-runtime` on windows-latest, ubuntu-latest, and macos-latest, prints `DOTNET_ROOT` and `dotnet --list-runtimes`, and asserts that `Microsoft.NETCore.App 8.x` is present and no `Microsoft.NETCore.App 10.x` is installed.

Expected before/after of the install lines:

Before (via `actions/setup-dotnet@v5`), both runtimes present:

```
Microsoft.NETCore.App 10.0.10 ...
Microsoft.NETCore.App 8.0.x ...
```

After (via `setup-dotnet-runtime`), net8 only:

```
Microsoft.NETCore.App 8.0.x ...
```

Actual output from this PR's `verify-dotnet-provisioning` run on windows-latest:

```
DOTNET_ROOT=D:\a\_temp\dotnet
DOTNET_ROLL_FORWARD=Disable
--- dotnet --list-runtimes ---
Microsoft.NETCore.App 8.0.29 [D:\a\_temp\dotnet\shared\Microsoft.NETCore.App]
OK: net8 runtime present, no net10 runtime.
```

All three OS jobs (windows, ubuntu, macos) pass with net8 present and no net10.

## Blast radius

`setup-r-env` is consumed by many OSP R package repos through the reusable check workflows, so this touches all of them. The change is conservative: the default `dotnet-version` (`8.0.x`) and the skip-on-empty behavior are preserved, the input grammar only widens (adds bare-major support; existing values behave identically), and net8 is still installed on every runner. The visible differences are that the .NET 10 runtime is no longer co-installed and that only the runtime (not the SDK) is provided, which is what the R checks actually need. No downstream repo needs to change anything.

## Context

The failure was first observed in the `OSPSuite-R` nightly "Update renv snapshot and check package" workflow, job "Test on windows-2025-vs2026". `rSharp` declares `SystemRequirements: dotnet8` and its net10 migration is tracked separately, so provisioning the net8 runtime is the correct target for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform automation for installing a pinned .NET runtime on Windows, macOS, and Linux.
  * Added support for exact versions, major versions, and release channels, with installation optionally disabled.

* **Documentation**
  * Clarified that environment setup uses the .NET runtime rather than the SDK.

* **Tests**
  * Added automated verification to confirm the expected .NET 8 runtime is installed and incompatible major versions are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->