### PR TITLE
Capture Windows crash dumps in R package check jobs

### DIFF
--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -85,6 +85,24 @@ jobs:
             ${{ inputs.build-binary && 'pkgbuild' || '' }}
             ${{ inputs.extra-packages }}
 
+      # OSP R packages intermittently crash with an access violation (0xC0000005) on
+      # Windows runners (Open-Systems-Pharmacology/OSPSuite-R#1996). Register a
+      # machine-wide Windows Error Reporting LocalDumps key so any process that
+      # crashes during the check writes a full dump, uploaded below on failure.
+      - name: Enable Windows crash dump capture
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'crashdumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $wer = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+          New-Item -Path "$wer\LocalDumps" -Force | Out-Null
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpFolder -Value $dumpDir -Type ExpandString
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
+          Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2
         with:
@@ -92,6 +110,15 @@ jobs:
           args: 'c("--no-manual")'
           build_args: 'c("--no-manual")'
           error-on: 'c("error")'
+
+      - name: Upload crash dumps
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-${{ matrix.config.os }}-r_${{ matrix.config.r }}
+          path: ${{ env.CRASH_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Build binary package
         if: inputs.build-binary

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -91,12 +91,39 @@ jobs:
           extra-packages: |
             rcmdcheck
 
+      # OSP R packages intermittently crash with an access violation (0xC0000005) on
+      # Windows runners (Open-Systems-Pharmacology/OSPSuite-R#1996). Register a
+      # machine-wide Windows Error Reporting LocalDumps key so any process that
+      # crashes during the check writes a full dump, uploaded below on failure.
+      - name: Enable Windows crash dump capture
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'crashdumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $wer = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+          New-Item -Path "$wer\LocalDumps" -Force | Out-Null
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpFolder -Value $dumpDir -Type ExpandString
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpType -Value 2 -Type DWord # full dump
+          Set-ItemProperty -Path "$wer\LocalDumps" -Name DumpCount -Value 5 -Type DWord
+          Set-ItemProperty -Path $wer -Name DontShowUI -Value 1 -Type DWord # never block on a WER dialog
+          "CRASH_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2
         with:
           args: 'c("--no-manual", "--no-vignettes")'
           build_args: 'c("--no-manual", "--no-build-vignettes")'
           error-on: 'c("error")'
+
+      - name: Upload crash dumps
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-${{ matrix.os }}
+          path: ${{ env.CRASH_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7
 
   commit-renv-lock:
     needs: [update-renv-lock, test-on-platforms]


### PR DESCRIPTION
## Why

OSP R packages intermittently crash with an access violation (0xC0000005) in Windows CI test runs — tracked in Open-Systems-Pharmacology/OSPSuite-R#1996. It is intermittent, so far Windows-only, and hits a different test file each time, so the failing test is likely a bystander and the exit code alone gives nothing to debug. All three observed instances ran through the two reusable workflows touched here (`R-CMD-check-build.yaml` for PR checks, `update-renv-lockfile.yaml` for the nightly renv update).

## What

Two Windows-only steps around `Check R package` in both workflows:

- **Before:** register the machine-wide [Windows Error Reporting LocalDumps](https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps) registry key so any process that crashes during the check writes a full dump (`DumpType=2`, up to 5 dumps) into `$RUNNER_TEMP\crashdumps`, and set `DontShowUI` so a WER dialog can never hang a job.
- **After:** on job failure, upload `*.dmp` as a `crash-dumps-*` artifact (`if-no-files-found: ignore`, so non-crash failures add no noise), retained 7 days.

Non-Windows runners and passing jobs are unaffected.

## Notes for review

- Full dumps (rather than minidumps) are deliberate: the suspected cause is heap/GC-state corruption in the R↔.NET bridge, and a stack-only minidump would likely show the corruption site without the context needed to attribute it.
- A full dump contains the job's process memory. The only secret present in these jobs' environment is the run-scoped `GITHUB_TOKEN`, which expires when the run completes; retention is capped at 7 days to be conservative.
- Once a dump is captured and analyzed, we can decide whether to keep, trim, or remove this instrumentation.

See Open-Systems-Pharmacology/OSPSuite-R#1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic capture of full Windows crash dumps during R package checks.
  * Failed Windows checks now upload available crash dumps as downloadable build artifacts.
  * Crash-dump collection is skipped when no dump files are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->