### PR TITLE
Expose an extra-repositories input in R-CMD-check workflows / setup-r-env

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -10,6 +10,15 @@ inputs:
     description: 'Use public RStudio Package Manager'
     required: false
     default: 'true'
+  extra-repositories:
+    description: >-
+      One or more extra CRAN-like repositories to include in the `repos` global
+      option. Can be a comma- or space-separated string (e.g.
+      'https://repo1.r-universe.dev, https://repo2.r-universe.dev'), or a YAML
+      list with one URL per line using the '|' block scalar syntax. Forwarded to
+      r-lib/actions/setup-r.
+    required: false
+    default: ''
   setup-pandoc:
     description: 'Whether to install pandoc'
     required: false
@@ -76,6 +85,7 @@ runs:
       with:
         r-version: ${{ inputs.r-version }}
         use-public-rspm: ${{ inputs.use-public-rspm }}
+        extra-repositories: ${{ inputs.extra-repositories }}
 
     - name: Check for renv.lock
       id: check-renv

--- a/.github/workflows/R-CMD-check-build.yaml
+++ b/.github/workflows/R-CMD-check-build.yaml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ''
+      extra-repositories:
+        description: 'Extra CRAN-like repositories to add to getOption("repos") (e.g. an R-universe such as https://open-systems-pharmacology.r-universe.dev, so pak can resolve dependencies from prebuilt binaries). Comma/space-separated, or one URL per line. Forwarded to setup-r-env.'
+        required: false
+        type: string
+        default: ''
       dotnet-version:
         description: '.NET SDK version to install on all runners (forwarded to setup-r-env). Set to an empty string to skip setup-dotnet and use whatever the runner image ships with (which may be no .NET at all, e.g. on macOS).'
         required: false
@@ -80,6 +85,7 @@ jobs:
           setup-quarto: ${{ inputs.setup-quarto }}
           ignore-renv: ${{ inputs.ignore-renv }}
           dotnet-version: ${{ inputs.dotnet-version }}
+          extra-repositories: ${{ inputs.extra-repositories }}
           extra-packages: |
             rcmdcheck
             ${{ inputs.build-binary && 'pkgbuild' || '' }}

--- a/.github/workflows/R-CMD-check-released-deps.yaml
+++ b/.github/workflows/R-CMD-check-released-deps.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         type: boolean
         default: false
+      extra-repositories:
+        description: 'Extra CRAN-like repositories to add to getOption("repos") (e.g. an R-universe such as https://open-systems-pharmacology.r-universe.dev, so pak can resolve dependencies from prebuilt binaries). Comma/space-separated, or one URL per line. Forwarded to setup-r-env.'
+        required: false
+        type: string
+        default: ''
 
 name: R-CMD-check-released-deps.yaml
 
@@ -73,6 +78,7 @@ jobs:
           setup-quarto: ${{ inputs.setup-quarto }}
           setup-tinytex: ${{ inputs.setup-tinytex }}
           ignore-renv: 'true'
+          extra-repositories: ${{ inputs.extra-repositories }}
           extra-packages: |
             rcmdcheck
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ flowchart TD
 
 These two scheduled checks are specific to packages that resolve some dependencies from GitHub via `Remotes:` in DESCRIPTION (typically OSP packages that depend on other OSP packages not published on CRAN). A package whose dependencies all come from CRAN has nothing to gain here and should skip this section.
 
+Resolving those OSP dependencies from GitHub `Remotes:` forces a from-source build of each one. If the dependencies are published on an R-universe (for example `https://open-systems-pharmacology.r-universe.dev`), you can instead have CI pull the prebuilt binaries by adding that repository to `getOption("repos")`. Every reusable check exposes an `extra-repositories` input for this (forwarded to `r-lib/actions/setup-r`); `pak` then resolves the dependency from the R-universe binaries rather than compiling the `Remotes` from source. The value accepts a comma- or space-separated string, or a YAML block list with one URL per line:
+
+```yaml
+jobs:
+  R-CMD-Check:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+    with:
+      extra-repositories: 'https://open-systems-pharmacology.r-universe.dev'
+```
+
 The pair catches drift in both directions: `check-dev-deps` checks against the current development dependencies (the unpinned Remotes as they stand in DESCRIPTION), while `check-released-deps` pins Remotes to `@*release` and checks against the latest released ones. Running both nightly surfaces a break early, whether it comes from an upstream development change or from a not-yet-released upstream fix the package has started relying on.
 
 <details>


### PR DESCRIPTION
The reusable R workflows could not add extra CRAN-like repositories to `getOption("repos")`, so a caller had no way to make CI resolve its dependencies from an R-universe. The `setup-r-env` composite action called `r-lib/actions/setup-r` without forwarding its `extra-repositories` input, and the reusable check workflows exposed no input to pass one down. This change exposes and forwards an `extra-repositories` input through the whole chain. It is purely additive: the empty default preserves current behaviour.

This lets a package that depends on other R-universe packages (for example the Open-Systems-Pharmacology universe) add, e.g., `https://open-systems-pharmacology.r-universe.dev` to `repos` so that `pak`/`setup-r-dependencies` resolves those dependencies from prebuilt binaries, instead of forcing a from-source GitHub build via `Remotes:`. `pak` resolves from `getOption("repos")` (and `Remotes`) but does not read the `Additional_repositories` field in DESCRIPTION, so the repository has to be added to `repos` for this to work.

## setup-r-env composite action

Adds an `extra-repositories` input (default `''`, wording taken from `r-lib/actions/setup-r`) and forwards it unconditionally to the `Setup R` step. An empty value is a no-op in `setup-r`, so behaviour is unchanged when the input is unset.

## R-CMD-check-build and R-CMD-check-released-deps

Both reusable workflows gain a matching `extra-repositories` input (default `''`) and forward it to `setup-r-env`. `R-CMD-check-released-deps` keeps its existing `@*release` Remotes pinning unchanged, so packages that resolve released dependencies through `Remotes:` alone are unaffected, while a package can now additionally point the check at an R-universe.

## README

Documents the new input in the nightly dependency checks section, explaining the R-universe-binaries alternative to a from-source `Remotes` build, with a short caller example.

Closes #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reusable R workflows now support additional CRAN-like repositories for dependency resolution.
  - CI setup can include alternative package sources, such as R-universe repositories.

- **Documentation**
  - Added guidance and a configuration example for using extra repositories in dependency checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->