### PR TITLE
Fixes #245 Invoke dotcover directly instead of dotnet dotcover

### DIFF
--- a/.github/actions/dotCover/action.yml
+++ b/.github/actions/dotCover/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: powershell
     
     - id: run-tests
-      run: dotnet dotcover cover ${{ inputs.xml-configuration }} --targetExecutable=./NUnit.ConsoleRunner.3.22.0/tools/nunit3-console.exe --output=coverageReport.xml --reportType=DetailedXML
+      run: dotcover cover ${{ inputs.xml-configuration }} --targetExecutable=./NUnit.ConsoleRunner.3.22.0/tools/nunit3-console.exe --output=coverageReport.xml --reportType=DetailedXML
       shell: powershell
 
     - uses: codecov/codecov-action@v5


### PR DESCRIPTION
dotCover CLI 2026.2.0 dropped the `dotnet-dotcover` shim; invoke `dotcover cover ...` instead. Fixes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)