### PR TITLE
Coverage: use dotnet test + Microsoft Code Coverage (net10)

### DIFF
--- a/.github/actions/dotCover/action.yml
+++ b/.github/actions/dotCover/action.yml
@@ -6,9 +6,6 @@ inputs:
   token:
     description: the codecov.io upload token
     required: true
-  xml-configuration:
-    description: 'Deprecated and ignored. Kept for backwards compatibility with callers that still pass the old dotCover config path.'
-    required: false
 
 runs:
   using: "composite"

--- a/.github/actions/dotCover/action.yml
+++ b/.github/actions/dotCover/action.yml
@@ -1,31 +1,36 @@
-name: 'Cover with JetBrains dotCover'
-description: 'Install and run JetBrains dotcover with an xml configuration'
+name: 'Code coverage'
+description: 'Collect code coverage with dotnet test (Microsoft Code Coverage) and upload cobertura to codecov'
 author: 'Robert McIntosh'
 
 inputs:
-  xml-configuration:
-    description: 'The xml file that configures the dotCover covearage'
-    required: true
   token:
     description: the codecov.io upload token
     required: true
+  xml-configuration:
+    description: 'Deprecated and ignored. Kept for backwards compatibility with callers that still pass the old dotCover config path.'
+    required: false
 
 runs:
   using: "composite"
   steps:
-    - id: install-prerequisites
-      run: |
-        dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2026.2.0
-        nuget install NUnit.ConsoleRunner -Version 3.22.0 -DirectDownload -OutputDirectory .
-      shell: powershell
-    
     - id: run-tests
-      run: dotcover cover ${{ inputs.xml-configuration }} --targetExecutable=./NUnit.ConsoleRunner.3.22.0/tools/nunit3-console.exe --output=coverageReport.xml --reportType=DetailedXML
+      # dotnet test auto-detects the single solution in the repo root and reuses the
+      # build produced by the calling workflow (--no-build). Coverage is collected by the
+      # Microsoft Code Coverage collector, which supports .NET 10 (JetBrains dotCover's
+      # console runner cannot generate a report on net10 - see DCVR-13230). When a
+      # coverage.runsettings is present it configures the collector (cobertura output and
+      # exclusions); otherwise a plain cobertura collection is used.
+      run: |
+        if (Test-Path "coverage.runsettings") {
+          dotnet test --no-build -c Debug --settings coverage.runsettings --results-directory coverage-results
+        } else {
+          dotnet test --no-build -c Debug --collect "Code Coverage;Format=cobertura" --results-directory coverage-results
+        }
       shell: powershell
 
     - uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
-        files: ./coverageReport.xml
+        directory: ./coverage-results
         token: ${{ inputs.token }}
         verbose: true


### PR DESCRIPTION
## Problem
JetBrains dotCover 2026.2 (only version that instruments .NET 10) cannot generate a coverage report — the console runner hangs/crashes in report generation ([DCVR-13230](https://youtrack.jetbrains.com/projects/DCVR/issues/DCVR-13230), open). Older versions cannot instrument net10. So even after #246, coverage produces no report.

## Fix
Rewrite the coverage action to run `dotnet test` with the Microsoft Code Coverage collector (net10-capable, emits cobertura for codecov). Auto-detects the repo's solution, reuses the workflow's build (`--no-build`), and uses `coverage.runsettings` when present.

The action now takes only `token`; the old `xml-configuration` input is removed. Consumers are being updated in the same round (PK-Sim, OSPSuite.Core, MoBi). Any consumer still passing `xml-configuration` will emit a harmless "unexpected input" warning, not fail.

Verified locally end-to-end instrumenting a net10 NUnit project and producing a valid cobertura report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)