### PR TITLE
Coverage: pass cobertura report to codecov explicitly

### DIFF
--- a/.github/actions/dotCover/action.yml
+++ b/.github/actions/dotCover/action.yml
@@ -23,11 +23,18 @@ runs:
         } else {
           dotnet test --no-build -c Debug --collect "Code Coverage;Format=cobertura" --results-directory coverage-results
         }
+        # The Microsoft Code Coverage collector writes the report to a machine/timestamp
+        # named file under a GUID subfolder (e.g. <machine>_<time>.cobertura.xml), which
+        # codecov's filename search does not match. Copy it to a stable path and hand it
+        # to codecov explicitly.
+        $report = Get-ChildItem coverage-results -Recurse -Filter *.cobertura.xml | Select-Object -First 1
+        if (-not $report) { Write-Error "No cobertura coverage report was produced by dotnet test"; exit 1 }
+        Copy-Item $report.FullName coverage-results/coverage.cobertura.xml -Force
       shell: powershell
 
     - uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
-        directory: ./coverage-results
+        files: ./coverage-results/coverage.cobertura.xml
         token: ${{ inputs.token }}
         verbose: true


### PR DESCRIPTION
Follow-up to #247. A PK-Sim coverage run confirmed `dotnet test` + Microsoft Code Coverage works on net10 (all tests pass, cobertura produced), but the codecov upload failed with "No coverage reports found": the collector names its file `<machine>_<timestamp>.cobertura.xml` under a GUID subfolder, which codecov's filename search doesn't match.

Fix: copy the produced report to a stable path (`coverage-results/coverage.cobertura.xml`) and pass it to codecov via `files` instead of relying on directory search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)