### PR TITLE
Expose extra-repositories in test-coverage, pkgdown and update-renv-lockfile

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      extra-repositories:
+        description: 'Extra CRAN-like repositories to add to getOption("repos") (e.g. an R-universe such as https://open-systems-pharmacology.r-universe.dev, so pak can resolve dependencies from prebuilt binaries). Comma/space-separated, or one URL per line. Forwarded to setup-r-env.'
+        required: false
+        type: string
+        default: ''
       doc-path-filters:
         description: 'YAML string for dorny/paths-filter. On PRs, pkgdown is skipped when none of these paths changed. Ignored on push events.'
         required: false
@@ -62,6 +67,7 @@ jobs:
         with:
           setup-pandoc: 'true'
           ignore-renv: ${{ inputs.ignore-renv }}
+          extra-repositories: ${{ inputs.extra-repositories }}
           extra-packages: |
             pkgdown
             local::.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: '8.0.x'
+      extra-repositories:
+        description: 'Extra CRAN-like repositories to add to getOption("repos") (e.g. an R-universe such as https://open-systems-pharmacology.r-universe.dev, so pak can resolve dependencies from prebuilt binaries). Comma/space-separated, or one URL per line. Forwarded to setup-r-env.'
+        required: false
+        type: string
+        default: ''
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -39,6 +44,7 @@ jobs:
         with:
           ignore-renv: ${{ inputs.ignore-renv }}
           dotnet-version: ${{ inputs.dotnet-version }}
+          extra-repositories: ${{ inputs.extra-repositories }}
           extra-packages: |
             covr
             local::.

--- a/.github/workflows/update-renv-lockfile.yaml
+++ b/.github/workflows/update-renv-lockfile.yaml
@@ -14,6 +14,11 @@ on:
           ["${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}",
           "${{ vars.GHA_DEFAULT_RUNNER_UBUNTU || 'ubuntu-latest' }}",
           "${{ vars.GHA_DEFAULT_RUNNER_MACOS || 'macos-latest' }}"]
+      extra-repositories:
+        description: 'Extra CRAN-like repositories to add to getOption("repos") (e.g. an R-universe such as https://open-systems-pharmacology.r-universe.dev, so renv and pak can resolve dependencies from prebuilt binaries). Comma/space-separated, or one URL per line. Used both when snapshotting the lockfile and when checking the package.'
+        required: false
+        type: string
+        default: ''
     secrets:
       private-key:
         required: true
@@ -35,6 +40,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: ${{ inputs.extra-repositories }}
 
       - name: Update project dependencies and snapshot lockfile
         shell: Rscript {0}
@@ -88,6 +94,7 @@ jobs:
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/setup-r-env@main
         with:
           setup-pandoc: 'true'
+          extra-repositories: ${{ inputs.extra-repositories }}
           extra-packages: |
             rcmdcheck
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ flowchart TD
 
 These two scheduled checks are specific to packages that resolve some dependencies from GitHub via `Remotes:` in DESCRIPTION (typically OSP packages that depend on other OSP packages not published on CRAN). A package whose dependencies all come from CRAN has nothing to gain here and should skip this section.
 
-Resolving those OSP dependencies from GitHub `Remotes:` forces a from-source build of each one. If the dependencies are published on an R-universe (for example `https://open-systems-pharmacology.r-universe.dev`), you can instead have CI pull the prebuilt binaries by adding that repository to `getOption("repos")`. Every reusable check exposes an `extra-repositories` input for this (forwarded to `r-lib/actions/setup-r`); `pak` then resolves the dependency from the R-universe binaries rather than compiling the `Remotes` from source. The value accepts a comma- or space-separated string, or a YAML block list with one URL per line:
+Resolving those OSP dependencies from GitHub `Remotes:` forces a from-source build of each one. If the dependencies are published on an R-universe (for example `https://open-systems-pharmacology.r-universe.dev`), you can instead have CI pull the prebuilt binaries by adding that repository to `getOption("repos")`. Every reusable R workflow that installs dependencies (`R-CMD-check-build`, `R-CMD-check-released-deps`, `test-coverage`, `pkgdown`, `update-renv-lockfile`) exposes an `extra-repositories` input for this (forwarded to `r-lib/actions/setup-r`); `pak` then resolves the dependency from the R-universe binaries rather than compiling the `Remotes` from source. The value accepts a comma- or space-separated string, or a YAML block list with one URL per line:
 
 ```yaml
 jobs:


### PR DESCRIPTION
Follow-up to #242, which added an `extra-repositories` input to `setup-r-env` and the two R-CMD-check workflows. The remaining reusable R workflows that install dependencies still had no way to add an R-universe (or any other CRAN-like repository) to `getOption("repos")`, so a caller resolving OSP dependencies from prebuilt R-universe binaries had to fall back to from-source `Remotes` builds in coverage, pkgdown and renv-lockfile runs. This exposes the same input there. Purely additive: empty default, existing callers unchanged.

## Workflows

- `test-coverage.yaml` and `pkgdown.yaml`: new `extra-repositories` input, forwarded to `setup-r-env` (same description and empty default as the R-CMD-check workflows).
- `update-renv-lockfile.yaml`: new `extra-repositories` input, used in both jobs that install packages. The snapshot job calls `r-lib/actions/setup-r` directly, so the input goes there; the per-OS check job gets it via `setup-r-env`. Passing it in both places means `renv::install(lock = TRUE)` records the lockfile against the same repositories the check later resolves from.

## Documentation

- `README.md`: the sentence claiming "every reusable check exposes an `extra-repositories` input" now names the five workflows that actually do (`R-CMD-check-build`, `R-CMD-check-released-deps`, `test-coverage`, `pkgdown`, `update-renv-lockfile`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reusable R workflows now support optional additional CRAN-like repositories, including R-universe sources, for dependency resolution.
  * These repositories are used during documentation builds, coverage checks, dependency checks, and lockfile updates.

* **Documentation**
  * Updated guidance clarifies which workflows support additional repositories and how prebuilt dependencies are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->